### PR TITLE
add age-at-VE reconstruction learning objective

### DIFF
--- a/scripts/run_linear_prob.sh
+++ b/scripts/run_linear_prob.sh
@@ -19,6 +19,7 @@ usage() {
     echo "  --add_random_token             Enable adding random token (disabled by default)"
     echo "  --tokenized_full_dataset_path=PATH Path to a pre-tokenized full dataset (optional)"
     echo "  --observation_window=NUM       Observation window in days (optional, default: None)"
+    echo "  --refresh_processed_dataset    Delete and rebuild the cached prepared dataset (disabled by default)"
     echo ""
     echo "Example:"
     echo "  $0 --base_dir=/path/to/cohorts --dataset_prepared_path=/path/to/dataset_prepared \\"
@@ -34,6 +35,7 @@ TORCH_TYPE="bfloat16"
 DISABLE_SAMPLE_PACKING="false"
 DISABLE_COMBINE_GLOBAL_LOCAL="false"
 ADD_RANDOM_TOKEN="false"
+REFRESH_PROCESSED_DATASET="false"
 TOKENIZED_FULL_DATASET_PATH=""
 OBSERVATION_WINDOW=""
 
@@ -81,6 +83,9 @@ for arg in "$@"; do
             ;;
         --observation_window=*)
             OBSERVATION_WINDOW="${arg#*=}"
+            ;;
+        --refresh_processed_dataset)
+            REFRESH_PROCESSED_DATASET="true"
             ;;
         --help|-h)
             usage
@@ -191,6 +196,7 @@ log "  --disable_combine_global_local=$DISABLE_COMBINE_GLOBAL_LOCAL"
 log "  --add_random_token=$ADD_RANDOM_TOKEN"
 log "  --tokenized_full_dataset_path=$TOKENIZED_FULL_DATASET_PATH"
 log "  --observation_window=$OBSERVATION_WINDOW"
+log "  --refresh_processed_dataset=$REFRESH_PROCESSED_DATASET"
 
 # Find valid cohorts and write to a temp file
 TEMP_COHORT_LIST="$LOG_DIR/cohort_list_${TIMESTAMP}.txt"
@@ -282,6 +288,10 @@ while read -r cohort_name; do
 
     if [ -n "$OBSERVATION_WINDOW" ]; then
         FEATURE_CMD="$FEATURE_CMD --observation_window \"$OBSERVATION_WINDOW\""
+    fi
+
+    if [ "$REFRESH_PROCESSED_DATASET" = "true" ]; then
+        FEATURE_CMD="$FEATURE_CMD --refresh_processed_dataset"
     fi
 
     # Step 1: Feature extraction

--- a/scripts/run_linear_prob.sh
+++ b/scripts/run_linear_prob.sh
@@ -19,7 +19,8 @@ usage() {
     echo "  --add_random_token             Enable adding random token (disabled by default)"
     echo "  --tokenized_full_dataset_path=PATH Path to a pre-tokenized full dataset (optional)"
     echo "  --observation_window=NUM       Observation window in days (optional, default: None)"
-    echo "  --refresh_processed_dataset    Delete and rebuild the cached prepared dataset (disabled by default)"
+    echo "  --refresh_processed_dataset    Delete and rebuild the cached prepared dataset (disabled by default)
+  --is_data_in_meds              Indicate that the data is in MEDS format (disabled by default)"
     echo ""
     echo "Example:"
     echo "  $0 --base_dir=/path/to/cohorts --dataset_prepared_path=/path/to/dataset_prepared \\"
@@ -36,6 +37,7 @@ DISABLE_SAMPLE_PACKING="false"
 DISABLE_COMBINE_GLOBAL_LOCAL="false"
 ADD_RANDOM_TOKEN="false"
 REFRESH_PROCESSED_DATASET="false"
+IS_DATA_IN_MEDS="false"
 TOKENIZED_FULL_DATASET_PATH=""
 OBSERVATION_WINDOW=""
 
@@ -86,6 +88,9 @@ for arg in "$@"; do
             ;;
         --refresh_processed_dataset)
             REFRESH_PROCESSED_DATASET="true"
+            ;;
+        --is_data_in_meds)
+            IS_DATA_IN_MEDS="true"
             ;;
         --help|-h)
             usage
@@ -197,6 +202,7 @@ log "  --add_random_token=$ADD_RANDOM_TOKEN"
 log "  --tokenized_full_dataset_path=$TOKENIZED_FULL_DATASET_PATH"
 log "  --observation_window=$OBSERVATION_WINDOW"
 log "  --refresh_processed_dataset=$REFRESH_PROCESSED_DATASET"
+log "  --is_data_in_meds=$IS_DATA_IN_MEDS"
 
 # Find valid cohorts and write to a temp file
 TEMP_COHORT_LIST="$LOG_DIR/cohort_list_${TIMESTAMP}.txt"
@@ -292,6 +298,10 @@ while read -r cohort_name; do
 
     if [ "$REFRESH_PROCESSED_DATASET" = "true" ]; then
         FEATURE_CMD="$FEATURE_CMD --refresh_processed_dataset"
+    fi
+
+    if [ "$IS_DATA_IN_MEDS" = "true" ]; then
+        FEATURE_CMD="$FEATURE_CMD --is_data_in_meds"
     fi
 
     # Step 1: Feature extraction

--- a/src/cehrgpt/data/cehrgpt_data_processor.py
+++ b/src/cehrgpt/data/cehrgpt_data_processor.py
@@ -157,7 +157,7 @@ class CehrGptDataProcessor(DatasetMapping):
             example["concept_ids"] = self.tokenizer.decode(
                 input_ids, skip_special_tokens=False
             )
-        example["ages"] = pd.Series(example["ages"]).ffill().tolist()
+        example["ages"] = pd.Series(example["ages"]).ffill().bfill().tolist()
         example = self.slice_out_input_sequence(example)
         # Add the motor labels
         if self.include_motor_time_to_event:

--- a/src/cehrgpt/data/hf_cehrgpt_dataset_collator.py
+++ b/src/cehrgpt/data/hf_cehrgpt_dataset_collator.py
@@ -26,7 +26,7 @@ class CehrGptDataCollator:
         pretraining: bool = True,
         include_demographics: bool = False,
         add_linear_prob_token: bool = False,
-        include_age_at_ve_prediction: bool = False,
+        include_age_at_vs_prediction: bool = False,
     ):
         self.tokenizer = tokenizer
         self.max_length = max_length
@@ -34,8 +34,8 @@ class CehrGptDataCollator:
         self.vs_token_id = tokenizer.vs_token_id
         self.ve_token_id = tokenizer.ve_token_id
 
-        self.include_age_at_ve_prediction = include_age_at_ve_prediction
-        if include_age_at_ve_prediction:
+        self.include_age_at_vs_prediction = include_age_at_vs_prediction
+        if include_age_at_vs_prediction:
             # Precompute valid integer age → vocabulary token id mapping.
             # Only ages whose 'age:<N>' token exists in the vocab are kept.
             self._age_to_token_id = {
@@ -179,7 +179,7 @@ class CehrGptDataCollator:
                 -100,
             )
 
-        if self.include_age_at_ve_prediction and self._age_to_token_id:
+        if self.include_age_at_vs_prediction and self._age_to_token_id:
             vs_mask = batch["input_ids"] == self.vs_token_id
             # Default all positions to -100 (ignored in loss)
             age_reconstruction_labels = torch.full_like(batch["input_ids"], -100)

--- a/src/cehrgpt/data/hf_cehrgpt_dataset_collator.py
+++ b/src/cehrgpt/data/hf_cehrgpt_dataset_collator.py
@@ -180,15 +180,15 @@ class CehrGptDataCollator:
             )
 
         if self.include_age_at_ve_prediction and self._age_to_token_id:
-            ve_mask = batch["input_ids"] == self.ve_token_id
+            vs_mask = batch["input_ids"] == self.vs_token_id
             # Default all positions to -100 (ignored in loss)
             age_reconstruction_labels = torch.full_like(batch["input_ids"], -100)
-            # At each VE position, if the integer age has a valid 'age:<N>' token,
+            # At each VS position, if the integer age has a valid 'age:<N>' token,
             # set the label to the integer age value.
             ages_int = batch["ages"].to(torch.int64)
             for age_val, _tok_id in self._age_to_token_id.items():
                 age_reconstruction_labels = torch.where(
-                    ve_mask & (ages_int == age_val),
+                    vs_mask & (ages_int == age_val),
                     age_val,
                     age_reconstruction_labels,
                 )

--- a/src/cehrgpt/data/hf_cehrgpt_dataset_collator.py
+++ b/src/cehrgpt/data/hf_cehrgpt_dataset_collator.py
@@ -26,12 +26,25 @@ class CehrGptDataCollator:
         pretraining: bool = True,
         include_demographics: bool = False,
         add_linear_prob_token: bool = False,
+        include_age_at_ve_prediction: bool = False,
     ):
         self.tokenizer = tokenizer
         self.max_length = max_length
 
         self.vs_token_id = tokenizer.vs_token_id
         self.ve_token_id = tokenizer.ve_token_id
+
+        self.include_age_at_ve_prediction = include_age_at_ve_prediction
+        if include_age_at_ve_prediction:
+            # Precompute valid integer age → vocabulary token id mapping.
+            # Only ages whose 'age:<N>' token exists in the vocab are kept.
+            self._age_to_token_id = {
+                age: tid
+                for age in tokenizer.valid_age_values
+                if (tid := tokenizer.get_age_token_id(age)) is not None
+            }
+        else:
+            self._age_to_token_id = {}
 
         self.include_values = include_values
         self.include_ttv_prediction = include_ttv_prediction
@@ -165,6 +178,21 @@ class CehrGptDataCollator:
                 batch["input_ids"],
                 -100,
             )
+
+        if self.include_age_at_ve_prediction and self._age_to_token_id:
+            ve_mask = batch["input_ids"] == self.ve_token_id
+            # Default all positions to -100 (ignored in loss)
+            age_reconstruction_labels = torch.full_like(batch["input_ids"], -100)
+            # At each VE position, if the integer age has a valid 'age:<N>' token,
+            # set the label to the integer age value.
+            ages_int = batch["ages"].to(torch.int64)
+            for age_val, _tok_id in self._age_to_token_id.items():
+                age_reconstruction_labels = torch.where(
+                    ve_mask & (ages_int == age_val),
+                    age_val,
+                    age_reconstruction_labels,
+                )
+            batch["age_reconstruction_labels"] = age_reconstruction_labels
 
         if self.use_sub_time_tokenization:
             time_token_indicators = torch.isin(batch["input_ids"], self.time_tokens)

--- a/src/cehrgpt/data/hf_cehrgpt_dataset_collator.py
+++ b/src/cehrgpt/data/hf_cehrgpt_dataset_collator.py
@@ -236,7 +236,7 @@ class CehrGptDataCollator:
         if self.include_motor_time_to_event:
 
             motor_row_indices = [example["motor_row_indices"] for example in examples]
-            row_index_pads = [0] + [max_row_index + 1 for max_row_index in map(max, motor_row_indices)][:-1]
+            row_index_pads = [0] + [max(indices, default=-1) + 1 for indices in motor_row_indices][:-1]
             row_index_pads = np.cumsum(row_index_pads)
             for i, row_index_pad in enumerate(row_index_pads):
                 motor_row_indices[i] = np.asarray(motor_row_indices[i]) + row_index_pad

--- a/src/cehrgpt/data/hf_cehrgpt_dataset_collator.py
+++ b/src/cehrgpt/data/hf_cehrgpt_dataset_collator.py
@@ -43,8 +43,18 @@ class CehrGptDataCollator:
                 for age in tokenizer.valid_age_values
                 if (tid := tokenizer.get_age_token_id(age)) is not None
             }
+            # Precompute a boolean lookup tensor so __call__ can validate ages with
+            # a single index operation instead of a Python loop over all valid ages.
+            if self._age_to_token_id:
+                _max_valid_age = max(self._age_to_token_id.keys())
+                self._valid_age_lookup = torch.zeros(_max_valid_age + 1, dtype=torch.bool)
+                for age in self._age_to_token_id:
+                    self._valid_age_lookup[age] = True
+            else:
+                self._valid_age_lookup = torch.zeros(0, dtype=torch.bool)
         else:
             self._age_to_token_id = {}
+            self._valid_age_lookup = torch.zeros(0, dtype=torch.bool)
 
         self.include_values = include_values
         self.include_ttv_prediction = include_ttv_prediction
@@ -181,17 +191,17 @@ class CehrGptDataCollator:
 
         if self.include_age_at_vs_prediction and self._age_to_token_id:
             vs_mask = batch["input_ids"] == self.vs_token_id
-            # Default all positions to -100 (ignored in loss)
-            age_reconstruction_labels = torch.full_like(batch["input_ids"], -100)
-            # At each VS position, if the integer age has a valid 'age:<N>' token,
-            # set the label to the integer age value.
             ages_int = batch["ages"].to(torch.int64)
-            for age_val, _tok_id in self._age_to_token_id.items():
-                age_reconstruction_labels = torch.where(
-                    vs_mask & (ages_int == age_val),
-                    age_val,
-                    age_reconstruction_labels,
-                )
+            # Use a precomputed boolean lookup tensor to validate ages in one shot,
+            # avoiding a Python loop over all ~121 valid age values.
+            lookup = self._valid_age_lookup.to(ages_int.device)
+            in_range = (ages_int >= 0) & (ages_int < lookup.shape[0])
+            valid_age_mask = lookup[ages_int.clamp(0, lookup.shape[0] - 1)] & in_range
+            age_reconstruction_labels = torch.where(
+                vs_mask & valid_age_mask,
+                ages_int,
+                torch.full_like(ages_int, -100),
+            )
             batch["age_reconstruction_labels"] = age_reconstruction_labels
 
         if self.use_sub_time_tokenization:

--- a/src/cehrgpt/data/hf_cehrgpt_dataset_mapping.py
+++ b/src/cehrgpt/data/hf_cehrgpt_dataset_mapping.py
@@ -30,6 +30,7 @@ from dateutil.relativedelta import relativedelta
 from pandas import Series
 
 from cehrgpt.gpt_utils import (
+    DEMOGRAPHIC_PROMPT_SIZE,
     construct_age_sequence,
     construct_time_sequence,
     encode_demographics,
@@ -561,9 +562,11 @@ class ExtractTokenizedSequenceDataMapping:
         self,
         person_index_date_map: Dict[int, List[Dict[str, Any]]],
         observation_window: int = 0,
+        tokenizer: Optional["CehrGptTokenizer"] = None,
     ):
         self.person_index_date_map = person_index_date_map
         self.observation_window = observation_window
+        self._tokenizer = tokenizer
 
     def _calculate_prediction_start_time(self, prediction_time: float):
         if self.observation_window and self.observation_window > 0:
@@ -587,27 +590,24 @@ class ExtractTokenizedSequenceDataMapping:
             )
             for prediction_time_label_map in prediction_times
         ]
-        observation_window_indices = np.zeros(
-            (len(prediction_times), len(record["epoch_times"])), dtype=bool
-        )
-        for i, epoch_time in enumerate(record["epoch_times"]):
-            for sample_n, (
-                feature_extraction_time_start,
-                feature_extraction_end_end,
-                _,
-            ) in enumerate(prediction_start_end_times):
-                if (
-                    feature_extraction_time_start
-                    <= epoch_time
-                    <= feature_extraction_end_end
-                ):
-                    observation_window_indices[sample_n][i] = True
 
-        seq_length = len(record["epoch_times"])
+        concept_ids = record["concept_ids"]
+        epoch_times = np.asarray(record["epoch_times"], dtype=float)
+        seq_length = len(epoch_times)
+
+        # The first DEMOGRAPHIC_PROMPT_SIZE tokens are always: year:YYYY, age:NN, gender, race.
+        # Derive birth_year so we can recalculate age at any observation window start.
+        try:
+            birth_year = int(concept_ids[0].split(":")[1]) - int(concept_ids[1].split(":")[1])
+        except Exception:
+            birth_year = None
+        original_gender = concept_ids[2]
+        original_race = concept_ids[3]
+
         time_series_columns = ["concept_ids", "input_ids"]
-        static_inputs = dict()
+        static_inputs = {}
         for k, v in record.items():
-            if k in ["concept_ids", "input_ids"]:
+            if k in ("concept_ids", "input_ids"):
                 continue
             if isinstance(v, (list, np.ndarray)) and len(v) == seq_length:
                 time_series_columns.append(k)
@@ -615,22 +615,68 @@ class ExtractTokenizedSequenceDataMapping:
                 static_inputs[k] = v
 
         batched_samples = defaultdict(list)
-        for (_, index_date, label), observation_window_index in zip(
-            prediction_start_end_times, observation_window_indices
-        ):
+        for feature_extraction_start, index_date, label in prediction_start_end_times:
+            # Find the first [VS] at or after the observation window start so that the
+            # extracted sequence always begins at a visit boundary.
+            vs_start_idx = None
+            for i in range(DEMOGRAPHIC_PROMPT_SIZE, seq_length):
+                if epoch_times[i] >= feature_extraction_start and concept_ids[i] == "[VS]":
+                    vs_start_idx = i
+                    break
+
+            if vs_start_idx is None:
+                # No visit starts within the observation window; skip this sample.
+                continue
+
+            # Find the last token at or before the index_date.
+            vs_end_idx = None
+            for i in range(seq_length - 1, DEMOGRAPHIC_PROMPT_SIZE - 1, -1):
+                if epoch_times[i] <= index_date:
+                    vs_end_idx = i
+                    break
+
+            if vs_end_idx is None or vs_end_idx < vs_start_idx:
+                continue
+
+            # Recalculate year and age at the start of the observation window.
+            vs_epoch_time = float(epoch_times[vs_start_idx])
+            new_year = datetime.datetime.utcfromtimestamp(vs_epoch_time).year
+            new_age = (new_year - birth_year) if birth_year is not None else -1
+            new_demographic_concept_ids = [
+                f"year:{new_year}", f"age:{new_age}", original_gender, original_race
+            ]
+
             for k, v in static_inputs.items():
                 batched_samples[k].append(v)
             batched_samples["classifier_label"].append(label)
             batched_samples["index_date"].append(index_date)
-            try:
-                start_age = int(record["concept_ids"][1].split(":")[1])
-            except Exception:
-                start_age = -1
-            batched_samples["age_at_index"].append(start_age)
-            for time_series_column in time_series_columns:
-                batched_samples[time_series_column].append(
-                    np.asarray(record[time_series_column])[observation_window_index]
-                )
+            batched_samples["age_at_index"].append(new_age)
+
+            for col in time_series_columns:
+                values = np.asarray(record[col])
+                sliced = values[vs_start_idx: vs_end_idx + 1]
+
+                if col == "concept_ids":
+                    demo = np.array(new_demographic_concept_ids)
+                    batched_samples[col].append(np.concatenate([demo, sliced]))
+                elif col == "input_ids":
+                    if self._tokenizer is not None:
+                        demo_ids = np.array(self._tokenizer.encode(new_demographic_concept_ids))
+                    else:
+                        # Fallback: reuse original demographic token ids unchanged.
+                        demo_ids = values[:DEMOGRAPHIC_PROMPT_SIZE]
+                    batched_samples[col].append(np.concatenate([demo_ids, sliced]))
+                elif col == "epoch_times":
+                    demo_times = np.full(DEMOGRAPHIC_PROMPT_SIZE, vs_epoch_time)
+                    batched_samples[col].append(np.concatenate([demo_times, sliced]))
+                elif col == "ages":
+                    demo_ages = np.full(DEMOGRAPHIC_PROMPT_SIZE, new_age)
+                    batched_samples[col].append(np.concatenate([demo_ages, sliced]))
+                else:
+                    # For mask/unit columns, reuse the original demographic token values (always 0/NA).
+                    demo_vals = values[:DEMOGRAPHIC_PROMPT_SIZE]
+                    batched_samples[col].append(np.concatenate([demo_vals, sliced]))
+
         return batched_samples
 
     def batch_transform(self, record: Dict[str, Any]) -> Dict[str, Any]:

--- a/src/cehrgpt/data/hf_cehrgpt_dataset_mapping.py
+++ b/src/cehrgpt/data/hf_cehrgpt_dataset_mapping.py
@@ -34,6 +34,7 @@ from cehrgpt.gpt_utils import (
     construct_age_sequence,
     construct_time_sequence,
     encode_demographics,
+    is_att_token,
     multiple_of_10,
 )
 from cehrgpt.models.tokenization_hf_cehrgpt import (
@@ -618,29 +619,35 @@ class ExtractTokenizedSequenceDataMapping:
         for feature_extraction_start, index_date, label in prediction_start_end_times:
             # Find the first [VS] at or after the observation window start so that the
             # extracted sequence always begins at a visit boundary.
-            vs_start_idx = None
+            obs_start_idx = None
             for i in range(DEMOGRAPHIC_PROMPT_SIZE, seq_length):
                 if epoch_times[i] >= feature_extraction_start and concept_ids[i] == "[VS]":
-                    vs_start_idx = i
+                    obs_start_idx = i
                     break
 
-            if vs_start_idx is None:
+            if obs_start_idx is None:
                 # No visit starts within the observation window; skip this sample.
                 continue
 
             # Find the last token at or before the index_date.
-            vs_end_idx = None
+            obs_end_idx = None
             for i in range(seq_length - 1, DEMOGRAPHIC_PROMPT_SIZE - 1, -1):
                 if epoch_times[i] <= index_date:
-                    vs_end_idx = i
+                    obs_end_idx = i
                     break
 
-            if vs_end_idx is None or vs_end_idx < vs_start_idx:
+            # If the prediction time lands in the middle of a visit (e.g. 24 h
+            # after admission), obs_end_idx may point at an ATT/time token.
+            # Step backward until we land on a non-time token.
+            while obs_end_idx is not None and obs_end_idx > obs_start_idx and is_att_token(concept_ids[obs_end_idx]):
+                obs_end_idx -= 1
+
+            if obs_end_idx is None or obs_end_idx < obs_start_idx:
                 continue
 
             # Recalculate year and age at the start of the observation window.
-            vs_epoch_time = float(epoch_times[vs_start_idx])
-            new_year = datetime.datetime.utcfromtimestamp(vs_epoch_time).year
+            obs_epoch_time = float(epoch_times[obs_start_idx])
+            new_year = datetime.datetime.utcfromtimestamp(obs_epoch_time).year
             new_age = (new_year - birth_year) if birth_year is not None else -1
             new_demographic_concept_ids = [
                 f"year:{new_year}", f"age:{new_age}", original_gender, original_race
@@ -654,7 +661,7 @@ class ExtractTokenizedSequenceDataMapping:
 
             for col in time_series_columns:
                 values = np.asarray(record[col])
-                sliced = values[vs_start_idx: vs_end_idx + 1]
+                sliced = values[obs_start_idx: obs_end_idx + 1]
 
                 if col == "concept_ids":
                     demo = np.array(new_demographic_concept_ids)
@@ -667,7 +674,7 @@ class ExtractTokenizedSequenceDataMapping:
                         demo_ids = values[:DEMOGRAPHIC_PROMPT_SIZE]
                     batched_samples[col].append(np.concatenate([demo_ids, sliced]))
                 elif col == "epoch_times":
-                    demo_times = np.full(DEMOGRAPHIC_PROMPT_SIZE, vs_epoch_time)
+                    demo_times = np.full(DEMOGRAPHIC_PROMPT_SIZE, obs_epoch_time)
                     batched_samples[col].append(np.concatenate([demo_times, sliced]))
                 elif col == "ages":
                     demo_ages = np.full(DEMOGRAPHIC_PROMPT_SIZE, new_age)

--- a/src/cehrgpt/data/hf_cehrgpt_dataset_mapping.py
+++ b/src/cehrgpt/data/hf_cehrgpt_dataset_mapping.py
@@ -566,31 +566,30 @@ class ExtractTokenizedSequenceDataMapping:
         tokenizer: Optional["CehrGptTokenizer"] = None,
     ):
         self.person_index_date_map = person_index_date_map
-        self.observation_window = observation_window
+        # Pre-compute the offset once so the inner loop does no arithmetic.
+        self._obs_window_seconds = (
+            observation_window * 24 * 3600
+            if observation_window and observation_window > 0
+            else 0
+        )
         self._tokenizer = tokenizer
-
-    def _calculate_prediction_start_time(self, prediction_time: float):
-        if self.observation_window and self.observation_window > 0:
-            return max(prediction_time - self.observation_window * 24 * 3600, 0)
-        return 0
 
     def transform(self, record: Dict[str, Any]) -> Dict[str, Any]:
         person_id = record["person_id"]
         prediction_times = self.person_index_date_map[person_id]
-        prediction_start_end_times = [
-            (
-                self._calculate_prediction_start_time(
-                    prediction_time_label_map["index_date"]
-                    .replace(tzinfo=datetime.timezone.utc)
-                    .timestamp()
-                ),
-                prediction_time_label_map["index_date"]
-                .replace(tzinfo=datetime.timezone.utc)
-                .timestamp(),
-                prediction_time_label_map["label"],
+
+        obs_window_seconds = self._obs_window_seconds
+        prediction_start_end_times = []
+        for ptm in prediction_times:
+            index_date_ts = (
+                ptm["index_date"].replace(tzinfo=datetime.timezone.utc).timestamp()
             )
-            for prediction_time_label_map in prediction_times
-        ]
+            feature_start = (
+                max(index_date_ts - obs_window_seconds, 0)
+                if obs_window_seconds > 0
+                else 0
+            )
+            prediction_start_end_times.append((feature_start, index_date_ts, ptm["label"]))
 
         concept_ids = record["concept_ids"]
         epoch_times = np.asarray(record["epoch_times"], dtype=float)
@@ -605,44 +604,51 @@ class ExtractTokenizedSequenceDataMapping:
         original_gender = concept_ids[2]
         original_race = concept_ids[3]
 
-        time_series_columns = ["concept_ids", "input_ids"]
-        static_inputs = {}
+        # Convert all time-series columns to numpy arrays once, before the prediction-time loop.
+        extra_ts_cols: List[str] = []
+        static_inputs: Dict[str, Any] = {}
+        col_arrays: Dict[str, np.ndarray] = {}
         for k, v in record.items():
             if k in ("concept_ids", "input_ids"):
                 continue
             if isinstance(v, (list, np.ndarray)) and len(v) == seq_length:
-                time_series_columns.append(k)
+                extra_ts_cols.append(k)
+                col_arrays[k] = np.asarray(v)
             else:
                 static_inputs[k] = v
 
-        batched_samples = defaultdict(list)
-        for feature_extraction_start, index_date, label in prediction_start_end_times:
-            # Find the first [VS] at or after the observation window start so that the
-            # extracted sequence always begins at a visit boundary.
-            obs_start_idx = None
-            for i in range(DEMOGRAPHIC_PROMPT_SIZE, seq_length):
-                if epoch_times[i] >= feature_extraction_start and concept_ids[i] == "[VS]":
-                    obs_start_idx = i
-                    break
+        concept_ids_arr = np.asarray(concept_ids)  # object array for string slicing
+        input_ids_arr = np.asarray(record["input_ids"]) if "input_ids" in record else None
 
-            if obs_start_idx is None:
-                # No visit starts within the observation window; skip this sample.
+        # Precompute a boolean ATT mask and the sorted array of [VS] positions
+        # so each prediction window needs only O(log n) work.
+        is_att_mask = np.array([is_att_token(c) for c in concept_ids])
+        vs_indices = np.where(concept_ids_arr == "[VS]")[0]
+        vs_indices = vs_indices[vs_indices >= DEMOGRAPHIC_PROMPT_SIZE]
+        vs_epoch_times = epoch_times[vs_indices]  # sorted because epoch_times is sorted
+
+        batched_samples: Dict[str, list] = defaultdict(list)
+        for feature_extraction_start, index_date, label in prediction_start_end_times:
+            # O(log k): find the first [VS] whose epoch_time >= feature_extraction_start.
+            vs_pos = int(np.searchsorted(vs_epoch_times, feature_extraction_start, side="left"))
+            if vs_pos >= len(vs_indices):
+                continue  # No visit starts within the observation window.
+            obs_start_idx = int(vs_indices[vs_pos])
+
+            # O(log n): find the last token whose epoch_time <= index_date.
+            obs_end_idx = int(np.searchsorted(epoch_times, index_date, side="right")) - 1
+            if obs_end_idx < DEMOGRAPHIC_PROMPT_SIZE:
                 continue
 
-            # Find the last token at or before the index_date.
-            obs_end_idx = None
-            for i in range(seq_length - 1, DEMOGRAPHIC_PROMPT_SIZE - 1, -1):
-                if epoch_times[i] <= index_date:
-                    obs_end_idx = i
-                    break
+            # If obs_end_idx landed on an ATT/time token (prediction time mid-visit),
+            # find the last non-ATT token in [obs_start_idx, obs_end_idx] via numpy.
+            if is_att_mask[obs_end_idx]:
+                non_att = np.where(~is_att_mask[obs_start_idx: obs_end_idx + 1])[0]
+                if len(non_att) == 0:
+                    continue
+                obs_end_idx = obs_start_idx + int(non_att[-1])
 
-            # If the prediction time lands in the middle of a visit (e.g. 24 h
-            # after admission), obs_end_idx may point at an ATT/time token.
-            # Step backward until we land on a non-time token.
-            while obs_end_idx is not None and obs_end_idx > obs_start_idx and is_att_token(concept_ids[obs_end_idx]):
-                obs_end_idx -= 1
-
-            if obs_end_idx is None or obs_end_idx < obs_start_idx:
+            if obs_end_idx < obs_start_idx:
                 continue
 
             # Recalculate year and age at the start of the observation window.
@@ -659,30 +665,29 @@ class ExtractTokenizedSequenceDataMapping:
             batched_samples["index_date"].append(index_date)
             batched_samples["age_at_index"].append(new_age)
 
-            for col in time_series_columns:
-                values = np.asarray(record[col])
-                sliced = values[obs_start_idx: obs_end_idx + 1]
+            sliced_concept_ids = concept_ids_arr[obs_start_idx: obs_end_idx + 1]
+            batched_samples["concept_ids"].append(
+                np.concatenate([np.array(new_demographic_concept_ids), sliced_concept_ids])
+            )
 
-                if col == "concept_ids":
-                    demo = np.array(new_demographic_concept_ids)
-                    batched_samples[col].append(np.concatenate([demo, sliced]))
-                elif col == "input_ids":
-                    if self._tokenizer is not None:
-                        demo_ids = np.array(self._tokenizer.encode(new_demographic_concept_ids))
-                    else:
-                        # Fallback: reuse original demographic token ids unchanged.
-                        demo_ids = values[:DEMOGRAPHIC_PROMPT_SIZE]
-                    batched_samples[col].append(np.concatenate([demo_ids, sliced]))
-                elif col == "epoch_times":
-                    demo_times = np.full(DEMOGRAPHIC_PROMPT_SIZE, obs_epoch_time)
-                    batched_samples[col].append(np.concatenate([demo_times, sliced]))
-                elif col == "ages":
-                    demo_ages = np.full(DEMOGRAPHIC_PROMPT_SIZE, new_age)
-                    batched_samples[col].append(np.concatenate([demo_ages, sliced]))
+            if input_ids_arr is not None:
+                sliced_input_ids = input_ids_arr[obs_start_idx: obs_end_idx + 1]
+                if self._tokenizer is not None:
+                    demo_ids = np.array(self._tokenizer.encode(new_demographic_concept_ids))
                 else:
-                    # For mask/unit columns, reuse the original demographic token values (always 0/NA).
-                    demo_vals = values[:DEMOGRAPHIC_PROMPT_SIZE]
-                    batched_samples[col].append(np.concatenate([demo_vals, sliced]))
+                    demo_ids = input_ids_arr[:DEMOGRAPHIC_PROMPT_SIZE]
+                batched_samples["input_ids"].append(np.concatenate([demo_ids, sliced_input_ids]))
+
+            for col in extra_ts_cols:
+                values = col_arrays[col]
+                sliced = values[obs_start_idx: obs_end_idx + 1]
+                if col == "epoch_times":
+                    demo = np.full(DEMOGRAPHIC_PROMPT_SIZE, obs_epoch_time)
+                elif col == "ages":
+                    demo = np.full(DEMOGRAPHIC_PROMPT_SIZE, new_age)
+                else:
+                    demo = values[:DEMOGRAPHIC_PROMPT_SIZE]
+                batched_samples[col].append(np.concatenate([demo, sliced]))
 
         return batched_samples
 

--- a/src/cehrgpt/generation/cehrgpt_conditional_generation.py
+++ b/src/cehrgpt/generation/cehrgpt_conditional_generation.py
@@ -235,7 +235,7 @@ def main():
         # If the full dataset has been tokenized, we don't want to tokenize the cohort containing
         # the subset of the data. We should slice out the portion of the tokenized sequences for each sample
         if cehrgpt_args.tokenized_full_dataset_path is not None:
-            processed_dataset = extract_cohort_sequences(data_args, cehrgpt_args)
+            processed_dataset = extract_cohort_sequences(data_args, cehrgpt_args, cehrgpt_tokenizer)
         else:
             # Organize them into a single DatasetDict
             final_splits = prepare_finetune_dataset(

--- a/src/cehrgpt/models/config.py
+++ b/src/cehrgpt/models/config.py
@@ -138,6 +138,7 @@ class CEHRGPTConfig(PretrainedConfig):
         motor_time_to_event_weight=1.0,
         motor_num_time_pieces=16,
         motor_time_bins: Optional[List[float]] = None,
+        motor_task_prevalence_rates: Optional[List[float]] = None,
         linear_prob_token_id=None,
         token_to_time_token_mapping: Dict[int, List] = None,
         use_pretrained_embeddings=False,
@@ -243,6 +244,7 @@ class CEHRGPTConfig(PretrainedConfig):
         self.motor_num_time_pieces = motor_num_time_pieces
         self.linear_prob_token_id = linear_prob_token_id
         self.motor_time_bins = motor_time_bins
+        self.motor_task_prevalence_rates = motor_task_prevalence_rates
 
         self.causal_sfm = causal_sfm
         self.demographics_size = demographics_size

--- a/src/cehrgpt/models/config.py
+++ b/src/cehrgpt/models/config.py
@@ -156,6 +156,9 @@ class CEHRGPTConfig(PretrainedConfig):
         entropy_penalty_alpha=0.01,
         sample_packing_max_positions=None,
         class_weights=None,
+        include_age_at_ve_prediction=False,
+        age_at_ve_vocab_size=None,
+        age_at_ve_prediction_loss_weight=1.0,
         **kwargs,
     ):
         if token_to_time_token_mapping is None:
@@ -219,6 +222,13 @@ class CEHRGPTConfig(PretrainedConfig):
         if self.include_motor_time_to_event and not ve_token_id:
             raise RuntimeError(
                 f"ve_token_id must be provided when include_motor_time_to_event is True"
+            )
+        self.include_age_at_ve_prediction = include_age_at_ve_prediction
+        self.age_at_ve_vocab_size = age_at_ve_vocab_size
+        self.age_at_ve_prediction_loss_weight = age_at_ve_prediction_loss_weight
+        if self.include_age_at_ve_prediction and not ve_token_id:
+            raise RuntimeError(
+                "ve_token_id must be provided when include_age_at_ve_prediction is True"
             )
         if self.include_motor_time_to_event and not linear_prob_token_id:
             raise RuntimeError(

--- a/src/cehrgpt/models/config.py
+++ b/src/cehrgpt/models/config.py
@@ -156,9 +156,9 @@ class CEHRGPTConfig(PretrainedConfig):
         entropy_penalty_alpha=0.01,
         sample_packing_max_positions=None,
         class_weights=None,
-        include_age_at_ve_prediction=False,
-        age_at_ve_vocab_size=None,
-        age_at_ve_prediction_loss_weight=1.0,
+        include_age_at_vs_prediction=False,
+        age_at_vs_vocab_size=None,
+        age_at_vs_prediction_loss_weight=1.0,
         **kwargs,
     ):
         if token_to_time_token_mapping is None:
@@ -223,12 +223,12 @@ class CEHRGPTConfig(PretrainedConfig):
             raise RuntimeError(
                 f"ve_token_id must be provided when include_motor_time_to_event is True"
             )
-        self.include_age_at_ve_prediction = include_age_at_ve_prediction
-        self.age_at_ve_vocab_size = age_at_ve_vocab_size
-        self.age_at_ve_prediction_loss_weight = age_at_ve_prediction_loss_weight
-        if self.include_age_at_ve_prediction and not ve_token_id:
+        self.include_age_at_vs_prediction = include_age_at_vs_prediction
+        self.age_at_vs_vocab_size = age_at_vs_vocab_size
+        self.age_at_vs_prediction_loss_weight = age_at_vs_prediction_loss_weight
+        if self.include_age_at_vs_prediction and not ve_token_id:
             raise RuntimeError(
-                "ve_token_id must be provided when include_age_at_ve_prediction is True"
+                "ve_token_id must be provided when include_age_at_vs_prediction is True"
             )
         if self.include_motor_time_to_event and not linear_prob_token_id:
             raise RuntimeError(

--- a/src/cehrgpt/models/hf_cehrgpt.py
+++ b/src/cehrgpt/models/hf_cehrgpt.py
@@ -84,6 +84,7 @@ class MotorTaskHead(nn.Module):
         input_dim,
         motor_tte_vocab_size,
         motor_num_time_pieces,
+        task_prevalence_rates=None,
         eps=1e-6,
     ):
         super(MotorTaskHead, self).__init__()
@@ -93,6 +94,14 @@ class MotorTaskHead(nn.Module):
         self.final_layer = nn.Linear(input_dim, input_dim * motor_num_time_pieces)
         self.norm = RMSNorm(input_dim, eps)
         self.task_layer = nn.Linear(input_dim, motor_tte_vocab_size)
+        # Initialise task_layer bias with log2(prevalence_rate) per task so the
+        # model starts with calibrated log-hazard predictions (matching the
+        # original MOTOR implementation) rather than zero for all tasks.
+        if task_prevalence_rates is not None:
+            start_bias = torch.log2(
+                torch.tensor(task_prevalence_rates, dtype=torch.float32)
+            )
+            self.task_layer.bias.data = start_bias
         self.task_time_bias = nn.Parameter(
             torch.zeros(1, self.motor_num_time_pieces, motor_tte_vocab_size)
         )
@@ -1158,6 +1167,7 @@ class CEHRGPT2LMHeadModel(CEHRGPTPreTrainedModel):
             input_dim=self.config.n_embd,
             motor_tte_vocab_size=self.config.motor_tte_vocab_size,
             motor_num_time_pieces=self.config.motor_num_time_pieces,
+            task_prevalence_rates=getattr(self.config, "motor_task_prevalence_rates", None),
         )
 
     def prepare_inputs_for_generation(

--- a/src/cehrgpt/models/hf_cehrgpt.py
+++ b/src/cehrgpt/models/hf_cehrgpt.py
@@ -1041,6 +1041,10 @@ class CEHRGPT2LMHeadModel(CEHRGPTPreTrainedModel):
             self.value_head = nn.Linear(
                 config.n_embd, config.value_vocab_size, bias=False
             )
+        if self.config.include_age_at_ve_prediction:
+            self.age_at_ve_head = nn.Linear(
+                config.n_embd, config.age_at_ve_vocab_size, bias=False
+            )
 
         self.motor_time_bins = None
         self.linear_prob = None
@@ -1335,6 +1339,7 @@ class CEHRGPT2LMHeadModel(CEHRGPTPreTrainedModel):
         return_dict: Optional[bool] = None,
         ages: Optional[torch.FloatTensor] = None,
         epoch_times: Optional[torch.FloatTensor] = None,
+        age_reconstruction_labels: Optional[torch.LongTensor] = None,
     ) -> Union[Tuple, CehrGptCausalLMOutput]:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
@@ -1418,6 +1423,7 @@ class CEHRGPT2LMHeadModel(CEHRGPTPreTrainedModel):
         time_to_visit_loss = None
         token_value_loss = None
         motor_tte_loss = None
+        age_at_ve_loss = None
 
         if labels is not None:
             # move labels to correct device to enable model parallelism
@@ -1606,6 +1612,22 @@ class CEHRGPT2LMHeadModel(CEHRGPTPreTrainedModel):
                     * float(not self.config.freeze_cehrgpt_generation_model)
                 )
 
+            if (
+                self.config.include_age_at_ve_prediction
+                and age_reconstruction_labels is not None
+            ):
+                age_logits = self.age_at_ve_head(hidden_states)
+                age_loss_fct = CrossEntropyLoss(ignore_index=-100, reduction="sum")
+                age_at_ve_loss = age_loss_fct(
+                    age_logits.view(-1, self.config.age_at_ve_vocab_size),
+                    age_reconstruction_labels.view(-1),
+                ) / total_num_tokens
+                loss += (
+                    age_at_ve_loss
+                    * self.config.age_at_ve_prediction_loss_weight
+                    * float(not self.config.freeze_cehrgpt_generation_model)
+                )
+
         if not return_dict:
             output = (lm_logits,) + transformer_outputs[1:]
             return ((loss,) + output) if loss is not None else output
@@ -1624,6 +1646,7 @@ class CEHRGPT2LMHeadModel(CEHRGPTPreTrainedModel):
             time_to_visit_loss=time_to_visit_loss,
             token_value_loss=token_value_loss,
             motor_tte_loss=motor_tte_loss,
+            age_at_ve_loss=age_at_ve_loss,
         )
 
     @staticmethod

--- a/src/cehrgpt/models/hf_cehrgpt.py
+++ b/src/cehrgpt/models/hf_cehrgpt.py
@@ -1041,9 +1041,9 @@ class CEHRGPT2LMHeadModel(CEHRGPTPreTrainedModel):
             self.value_head = nn.Linear(
                 config.n_embd, config.value_vocab_size, bias=False
             )
-        if self.config.include_age_at_ve_prediction:
-            self.age_at_ve_head = nn.Linear(
-                config.n_embd, config.age_at_ve_vocab_size, bias=False
+        if self.config.include_age_at_vs_prediction:
+            self.age_at_vs_head = nn.Linear(
+                config.n_embd, config.age_at_vs_vocab_size, bias=False
             )
 
         self.motor_time_bins = None
@@ -1423,7 +1423,7 @@ class CEHRGPT2LMHeadModel(CEHRGPTPreTrainedModel):
         time_to_visit_loss = None
         token_value_loss = None
         motor_tte_loss = None
-        age_at_ve_loss = None
+        age_at_vs_loss = None
 
         if labels is not None:
             # move labels to correct device to enable model parallelism
@@ -1613,18 +1613,18 @@ class CEHRGPT2LMHeadModel(CEHRGPTPreTrainedModel):
                 )
 
             if (
-                self.config.include_age_at_ve_prediction
+                self.config.include_age_at_vs_prediction
                 and age_reconstruction_labels is not None
             ):
-                age_logits = self.age_at_ve_head(hidden_states)
+                age_logits = self.age_at_vs_head(hidden_states)
                 age_loss_fct = CrossEntropyLoss(ignore_index=-100, reduction="sum")
-                age_at_ve_loss = age_loss_fct(
-                    age_logits.view(-1, self.config.age_at_ve_vocab_size),
+                age_at_vs_loss = age_loss_fct(
+                    age_logits.view(-1, self.config.age_at_vs_vocab_size),
                     age_reconstruction_labels.view(-1),
                 ) / total_num_tokens
                 loss += (
-                    age_at_ve_loss
-                    * self.config.age_at_ve_prediction_loss_weight
+                    age_at_vs_loss
+                    * self.config.age_at_vs_prediction_loss_weight
                     * float(not self.config.freeze_cehrgpt_generation_model)
                 )
 
@@ -1646,7 +1646,7 @@ class CEHRGPT2LMHeadModel(CEHRGPTPreTrainedModel):
             time_to_visit_loss=time_to_visit_loss,
             token_value_loss=token_value_loss,
             motor_tte_loss=motor_tte_loss,
-            age_at_ve_loss=age_at_ve_loss,
+            age_at_vs_loss=age_at_vs_loss,
         )
 
     @staticmethod

--- a/src/cehrgpt/models/hf_modeling_outputs.py
+++ b/src/cehrgpt/models/hf_modeling_outputs.py
@@ -87,6 +87,7 @@ class CehrGptCausalLMOutput(ModelOutput):
     time_to_visit_loss: Optional[torch.FloatTensor] = None
     token_value_loss: Optional[torch.FloatTensor] = None
     motor_tte_loss: Optional[torch.FloatTensor] = None
+    age_at_ve_loss: Optional[torch.FloatTensor] = None
 
 
 @dataclass

--- a/src/cehrgpt/models/hf_modeling_outputs.py
+++ b/src/cehrgpt/models/hf_modeling_outputs.py
@@ -87,7 +87,7 @@ class CehrGptCausalLMOutput(ModelOutput):
     time_to_visit_loss: Optional[torch.FloatTensor] = None
     token_value_loss: Optional[torch.FloatTensor] = None
     motor_tte_loss: Optional[torch.FloatTensor] = None
-    age_at_ve_loss: Optional[torch.FloatTensor] = None
+    age_at_vs_loss: Optional[torch.FloatTensor] = None
 
 
 @dataclass

--- a/src/cehrgpt/runners/data_utils.py
+++ b/src/cehrgpt/runners/data_utils.py
@@ -420,13 +420,20 @@ def extract_cohort_sequences(
             len(missing_person_ids),
             missing_person_ids,
         )
-    processed_dataset = filtered_tokenized_dataset.map(
-        ExtractTokenizedSequenceDataMapping(
-            person_index_date_map, data_args.observation_window, tokenizer
-        ).batch_transform,
-        batched=True,
-        batch_size=data_args.preprocessing_batch_size,
-        num_proc=data_args.preprocessing_num_workers,
-        remove_columns=filtered_tokenized_dataset["train"].column_names,
-    )
-    return processed_dataset
+    mapping_fn = ExtractTokenizedSequenceDataMapping(
+        person_index_date_map, data_args.observation_window, tokenizer
+    ).batch_transform
+    max_workers = data_args.preprocessing_num_workers
+    # Apply per-split so num_proc scales with split size.
+    # Process startup overhead dominates for small splits when num_proc is large.
+    processed_splits = {}
+    for split_name, split_ds in filtered_tokenized_dataset.items():
+        num_proc = min(max_workers, max(1, len(split_ds) // 1000))
+        processed_splits[split_name] = split_ds.map(
+            mapping_fn,
+            batched=True,
+            batch_size=data_args.preprocessing_batch_size,
+            num_proc=num_proc,
+            remove_columns=split_ds.column_names,
+        )
+    return DatasetDict(processed_splits)

--- a/src/cehrgpt/runners/data_utils.py
+++ b/src/cehrgpt/runners/data_utils.py
@@ -23,6 +23,7 @@ from cehrgpt.data.hf_cehrgpt_dataset_mapping import (
     ExtractTokenizedSequenceDataMapping,
     MedToCehrGPTDatasetMapping,
 )
+from cehrgpt.models.tokenization_hf_cehrgpt import CehrGptTokenizer
 from cehrgpt.runners.hf_gpt_runner_argument_dataclass import CehrGPTArguments
 
 LOG = logging.get_logger("transformers")
@@ -323,6 +324,7 @@ def create_dataset_splits(
 def extract_cohort_sequences(
     data_args: DataTrainingArguments,
     cehrgpt_args: CehrGPTArguments,
+    tokenizer: Optional[CehrGptTokenizer] = None,
 ) -> DatasetDict:
     """
     Extracts and processes cohort-specific tokenized sequences from a pre-tokenized dataset,.
@@ -337,13 +339,17 @@ def extract_cohort_sequences(
     4. Aggregates each person's index date and label into a mapping.
     5. Checks for consistency to ensure all cohort person_ids are present in the tokenized dataset.
     6. Applies a transformation (`ExtractTokenizedSequenceDataMapping`) to generate
-       observation-window-constrained patient sequences.
+       observation-window-constrained patient sequences, with recalculated demographic tokens
+       prepended to each extracted slice.
     7. Caches both the filtered and processed datasets using the provided `cache_file_collector`.
 
     Args:
         data_args (DataTrainingArguments): Configuration parameters for data processing,
             including cohort folder, observation window, batch size, and parallelism.
         cehrgpt_args (CehrGPTArguments): Contains paths to pre-tokenized datasets and CEHR-GPT-specific arguments.
+        tokenizer (Optional[CehrGptTokenizer]): Tokenizer used to encode the recalculated demographic
+            tokens (year, age) for the `input_ids` column. If ``None``, the original demographic
+            token ids are reused as a fallback.
     Returns:
         DatasetDict: A Hugging Face `DatasetDict` containing the processed datasets (e.g., train/validation/test),
                      where each entry includes sequences filtered and truncated by the observation window.
@@ -416,7 +422,7 @@ def extract_cohort_sequences(
         )
     processed_dataset = filtered_tokenized_dataset.map(
         ExtractTokenizedSequenceDataMapping(
-            person_index_date_map, data_args.observation_window
+            person_index_date_map, data_args.observation_window, tokenizer
         ).batch_transform,
         batched=True,
         batch_size=data_args.preprocessing_batch_size,

--- a/src/cehrgpt/runners/data_utils.py
+++ b/src/cehrgpt/runners/data_utils.py
@@ -1,3 +1,4 @@
+import math
 import os
 from datetime import datetime
 from typing import Dict, List, Optional, Union, Tuple
@@ -139,6 +140,13 @@ def prepare_finetune_dataset(
     return final_splits
 
 
+def _clamp_num_proc(dataset_len: int, num_proc: Optional[int], batch_size: int) -> Optional[int]:
+    """Clamp num_proc so we don't spawn more workers than there are batches."""
+    if num_proc is None:
+        return None
+    return min(num_proc, max(1, math.ceil(dataset_len / batch_size)))
+
+
 # Helper function to apply patient-based filtering
 def filter_by_patient_ids(
         dataset: Dataset,
@@ -148,7 +156,7 @@ def filter_by_patient_ids(
     unique_ids = set(patient_ids)
     return dataset.filter(
         lambda batch: [pid in unique_ids for pid in batch["person_id"]],
-        num_proc=data_args.preprocessing_num_workers,
+        num_proc=_clamp_num_proc(len(dataset), data_args.preprocessing_num_workers, data_args.preprocessing_batch_size),
         batched=True,
         batch_size=data_args.preprocessing_batch_size,
     )
@@ -389,12 +397,18 @@ def extract_cohort_sequences(
 
     # data_args.observation_window
     tokenized_dataset = load_from_disk(cehrgpt_args.tokenized_full_dataset_path)
-    filtered_tokenized_dataset = tokenized_dataset.filter(
-        lambda batch: [person_id in all_person_ids for person_id in batch["person_id"]],
-        batched=True,
-        batch_size=data_args.preprocessing_batch_size,
-        num_proc=data_args.preprocessing_num_workers,
-    )
+
+    all_person_ids_set = set(all_person_ids)
+    filtered_tokenized_dataset = DatasetDict({
+        split: ds.filter(
+            lambda batch: [pid in all_person_ids_set for pid in batch["person_id"]],
+            batched=True,
+            batch_size=data_args.preprocessing_batch_size,
+            num_proc=_clamp_num_proc(len(ds), data_args.preprocessing_num_workers, data_args.preprocessing_batch_size),
+        )
+        for split, ds in tokenized_dataset.items()
+    })
+
     person_index_date_agg = cohort.group_by("person_id").agg(
         pl.struct("index_date", "label").alias("index_date_label")
     )
@@ -420,20 +434,17 @@ def extract_cohort_sequences(
             len(missing_person_ids),
             missing_person_ids,
         )
-    mapping_fn = ExtractTokenizedSequenceDataMapping(
+    transform = ExtractTokenizedSequenceDataMapping(
         person_index_date_map, data_args.observation_window, tokenizer
-    ).batch_transform
-    max_workers = data_args.preprocessing_num_workers
-    # Apply per-split so num_proc scales with split size.
-    # Process startup overhead dominates for small splits when num_proc is large.
-    processed_splits = {}
-    for split_name, split_ds in filtered_tokenized_dataset.items():
-        num_proc = min(max_workers, max(1, len(split_ds) // 1000))
-        processed_splits[split_name] = split_ds.map(
-            mapping_fn,
+    )
+    processed_dataset = DatasetDict({
+        split: ds.map(
+            transform.batch_transform,
             batched=True,
             batch_size=data_args.preprocessing_batch_size,
-            num_proc=num_proc,
-            remove_columns=split_ds.column_names,
+            num_proc=_clamp_num_proc(len(ds), data_args.preprocessing_num_workers, data_args.preprocessing_batch_size),
+            remove_columns=ds.column_names,
         )
-    return DatasetDict(processed_splits)
+        for split, ds in filtered_tokenized_dataset.items()
+    })
+    return processed_dataset

--- a/src/cehrgpt/runners/hf_cehrgpt_finetune_runner.py
+++ b/src/cehrgpt/runners/hf_cehrgpt_finetune_runner.py
@@ -294,6 +294,10 @@ def main():
     cache_file_collector = CacheFileCollector()
     processed_dataset = None
 
+    if cehrgpt_args.refresh_processed_dataset and prepared_ds_path.exists():
+        LOG.info("Refreshing prepared dataset: removing cache at %s", prepared_ds_path)
+        shutil.rmtree(prepared_ds_path)
+
     if any(prepared_ds_path.glob("*")):
         LOG.info("Loading prepared dataset from disk at %s...", prepared_ds_path)
         processed_dataset = load_from_disk(str(prepared_ds_path))

--- a/src/cehrgpt/runners/hf_cehrgpt_finetune_runner.py
+++ b/src/cehrgpt/runners/hf_cehrgpt_finetune_runner.py
@@ -242,7 +242,7 @@ def _create_finetune_dataset(
     """Process the raw finetuning data into a tokenized DatasetDict and save the tokenizer."""
     # If the full dataset has been pre-tokenized, slice out the cohort sequences directly
     if cehrgpt_args.tokenized_full_dataset_path is not None:
-        return extract_cohort_sequences(data_args, cehrgpt_args)
+        return extract_cohort_sequences(data_args, cehrgpt_args, tokenizer)
 
     final_splits = prepare_finetune_dataset(
         data_args, training_args, cehrgpt_args, cache_file_collector

--- a/src/cehrgpt/runners/hf_cehrgpt_pretrain_runner.py
+++ b/src/cehrgpt/runners/hf_cehrgpt_pretrain_runner.py
@@ -664,6 +664,7 @@ def main():
                 if "validation" in processed_dataset
                 else processed_dataset["test"]
             )["num_of_concepts"],
+            aux_loss_warmup_steps=cehrgpt_args.aux_loss_warmup_steps,
         )
         training_args.per_device_train_batch_size = 1
         training_args.per_device_eval_batch_size = 1
@@ -673,7 +674,10 @@ def main():
             model_args.max_position_embeddings,
         )
     else:
-        trainer_class = CehrGptTrainer
+        trainer_class = partial(
+            CehrGptTrainer,
+            aux_loss_warmup_steps=cehrgpt_args.aux_loss_warmup_steps,
+        )
         data_collator_fn = CehrGptDataCollator
 
     trainer = trainer_class(

--- a/src/cehrgpt/runners/hf_cehrgpt_pretrain_runner.py
+++ b/src/cehrgpt/runners/hf_cehrgpt_pretrain_runner.py
@@ -223,13 +223,13 @@ def load_and_create_model(
             ),
             include_motor_time_to_event=cehrgpt_args.include_motor_time_to_event,
             freeze_cehrgpt_generation_model=cehrgpt_args.freeze_cehrgpt_generation_model,
-            include_age_at_ve_prediction=cehrgpt_args.include_age_at_ve_prediction,
-            age_at_ve_vocab_size=(
-                tokenizer.age_at_ve_vocab_size
-                if cehrgpt_args.include_age_at_ve_prediction
+            include_age_at_vs_prediction=cehrgpt_args.include_age_at_vs_prediction,
+            age_at_vs_vocab_size=(
+                tokenizer.age_at_vs_vocab_size
+                if cehrgpt_args.include_age_at_vs_prediction
                 else None
             ),
-            age_at_ve_prediction_loss_weight=cehrgpt_args.age_at_ve_prediction_loss_weight,
+            age_at_vs_prediction_loss_weight=cehrgpt_args.age_at_vs_prediction_loss_weight,
             motor_tte_vocab_size=tokenizer.motor_tte_vocab_size,
             motor_time_to_event_weight=cehrgpt_args.motor_time_to_event_weight,
             motor_num_time_pieces=cehrgpt_args.motor_num_time_pieces,
@@ -251,10 +251,17 @@ def load_and_create_model(
             tokenizer.pretrained_embeddings,
         )
 
+    LOG.info("Model vocab_size: %s", model.config.vocab_size)
+    LOG.info("Model value_vocab_size: %s", getattr(model.config, "value_vocab_size", 0))
+    LOG.info("Model time_token_vocab_size: %s", getattr(model.config, "time_token_vocab_size", 0))
+    LOG.info("Model motor_tte_vocab_size: %s", getattr(model.config, "motor_tte_vocab_size", 0))
+    LOG.info("Model age_at_vs_vocab_size: %s", getattr(model.config, "age_at_vs_vocab_size", 0))
+
     if model.config.torch_dtype == torch.bfloat16:
         return model.bfloat16()
     elif model.config.torch_dtype == torch.float16:
         return model.half()
+
     return model
 
 
@@ -685,7 +692,7 @@ def main():
             include_motor_time_to_event=cehrgpt_args.include_motor_time_to_event,
             motor_sampling_probability=cehrgpt_args.motor_sampling_probability,
             is_data_in_meds=data_args.is_data_in_meds,
-            include_age_at_ve_prediction=cehrgpt_args.include_age_at_ve_prediction,
+            include_age_at_vs_prediction=cehrgpt_args.include_age_at_vs_prediction,
         ),
         train_dataset=processed_dataset["train"],
         eval_dataset=(

--- a/src/cehrgpt/runners/hf_cehrgpt_pretrain_runner.py
+++ b/src/cehrgpt/runners/hf_cehrgpt_pretrain_runner.py
@@ -223,6 +223,13 @@ def load_and_create_model(
             ),
             include_motor_time_to_event=cehrgpt_args.include_motor_time_to_event,
             freeze_cehrgpt_generation_model=cehrgpt_args.freeze_cehrgpt_generation_model,
+            include_age_at_ve_prediction=cehrgpt_args.include_age_at_ve_prediction,
+            age_at_ve_vocab_size=(
+                tokenizer.age_at_ve_vocab_size
+                if cehrgpt_args.include_age_at_ve_prediction
+                else None
+            ),
+            age_at_ve_prediction_loss_weight=cehrgpt_args.age_at_ve_prediction_loss_weight,
             motor_tte_vocab_size=tokenizer.motor_tte_vocab_size,
             motor_time_to_event_weight=cehrgpt_args.motor_time_to_event_weight,
             motor_num_time_pieces=cehrgpt_args.motor_num_time_pieces,
@@ -678,6 +685,7 @@ def main():
             include_motor_time_to_event=cehrgpt_args.include_motor_time_to_event,
             motor_sampling_probability=cehrgpt_args.motor_sampling_probability,
             is_data_in_meds=data_args.is_data_in_meds,
+            include_age_at_ve_prediction=cehrgpt_args.include_age_at_ve_prediction,
         ),
         train_dataset=processed_dataset["train"],
         eval_dataset=(

--- a/src/cehrgpt/runners/hf_cehrgpt_pretrain_runner.py
+++ b/src/cehrgpt/runners/hf_cehrgpt_pretrain_runner.py
@@ -236,6 +236,7 @@ def load_and_create_model(
             motor_time_bins=tokenizer.get_motor_time_bins(
                 cehrgpt_args.motor_num_time_pieces
             ),
+            motor_task_prevalence_rates=tokenizer.get_motor_task_prevalence_rates(),
             linear_prob_n_layer=cehrgpt_args.linear_prob_n_layer,
             ve_token_id=tokenizer.ve_token_id,
             linear_prob_token_id=tokenizer.linear_token_id,

--- a/src/cehrgpt/runners/hf_cehrgpt_pretrain_runner.py
+++ b/src/cehrgpt/runners/hf_cehrgpt_pretrain_runner.py
@@ -41,7 +41,7 @@ from cehrgpt.omop.ontology import Ontology
 from cehrgpt.runners.data_utils import get_torch_dtype, load_patient_splits, filter_by_patient_ids
 from cehrgpt.runners.gpt_runner_util import parse_runner_args
 from cehrgpt.runners.hf_gpt_runner_argument_dataclass import CehrGPTArguments
-from cehrgpt.runners.sample_packing_trainer import SamplePackingTrainer
+from cehrgpt.runners.sample_packing_trainer import CehrGptTrainer, SamplePackingTrainer
 
 LOG = logging.get_logger("transformers")
 
@@ -666,7 +666,7 @@ def main():
             model_args.max_position_embeddings,
         )
     else:
-        trainer_class = Trainer
+        trainer_class = CehrGptTrainer
         data_collator_fn = CehrGptDataCollator
 
     trainer = trainer_class(

--- a/src/cehrgpt/runners/hf_cehrgpt_pretrain_runner.py
+++ b/src/cehrgpt/runners/hf_cehrgpt_pretrain_runner.py
@@ -665,6 +665,7 @@ def main():
                 else processed_dataset["test"]
             )["num_of_concepts"],
             aux_loss_warmup_steps=cehrgpt_args.aux_loss_warmup_steps,
+            aux_loss_start_step=cehrgpt_args.aux_loss_start_step,
         )
         training_args.per_device_train_batch_size = 1
         training_args.per_device_eval_batch_size = 1
@@ -677,6 +678,7 @@ def main():
         trainer_class = partial(
             CehrGptTrainer,
             aux_loss_warmup_steps=cehrgpt_args.aux_loss_warmup_steps,
+            aux_loss_start_step=cehrgpt_args.aux_loss_start_step,
         )
         data_collator_fn = CehrGptDataCollator
 

--- a/src/cehrgpt/runners/hf_gpt_runner_argument_dataclass.py
+++ b/src/cehrgpt/runners/hf_gpt_runner_argument_dataclass.py
@@ -282,3 +282,11 @@ class CehrGPTArguments:
         default=1.0,
         metadata={"help": "Loss weight for the age-at-VE prediction objective."},
     )
+    aux_loss_warmup_steps: int = dataclasses.field(
+        default=0,
+        metadata={
+            "help": "Number of training steps over which auxiliary losses (all losses except "
+            "token_loss) are linearly ramped from 0 to their full weight. "
+            "Set to 0 (default) to disable warmup and use full weights from the start."
+        },
+    )

--- a/src/cehrgpt/runners/hf_gpt_runner_argument_dataclass.py
+++ b/src/cehrgpt/runners/hf_gpt_runner_argument_dataclass.py
@@ -270,7 +270,7 @@ class CehrGPTArguments:
             "help": "A flag to indicate whether we want to use linear prob tokens"
         },
     )
-    include_age_at_ve_prediction: Optional[bool] = dataclasses.field(
+    include_age_at_vs_prediction: Optional[bool] = dataclasses.field(
         default=False,
         metadata={
             "help": "A flag to include the age-at-VE reconstruction learning objective, "
@@ -278,7 +278,7 @@ class CehrGPTArguments:
             "The age vocab size is derived automatically from the tokenizer vocabulary."
         },
     )
-    age_at_ve_prediction_loss_weight: Optional[float] = dataclasses.field(
+    age_at_vs_prediction_loss_weight: Optional[float] = dataclasses.field(
         default=1.0,
         metadata={"help": "Loss weight for the age-at-VE prediction objective."},
     )

--- a/src/cehrgpt/runners/hf_gpt_runner_argument_dataclass.py
+++ b/src/cehrgpt/runners/hf_gpt_runner_argument_dataclass.py
@@ -270,3 +270,15 @@ class CehrGPTArguments:
             "help": "A flag to indicate whether we want to use linear prob tokens"
         },
     )
+    include_age_at_ve_prediction: Optional[bool] = dataclasses.field(
+        default=False,
+        metadata={
+            "help": "A flag to include the age-at-VE reconstruction learning objective, "
+            "which predicts patient age at each [VE] token using cross-entropy loss. "
+            "The age vocab size is derived automatically from the tokenizer vocabulary."
+        },
+    )
+    age_at_ve_prediction_loss_weight: Optional[float] = dataclasses.field(
+        default=1.0,
+        metadata={"help": "Loss weight for the age-at-VE prediction objective."},
+    )

--- a/src/cehrgpt/runners/hf_gpt_runner_argument_dataclass.py
+++ b/src/cehrgpt/runners/hf_gpt_runner_argument_dataclass.py
@@ -287,6 +287,15 @@ class CehrGPTArguments:
         metadata={
             "help": "Number of training steps over which auxiliary losses (all losses except "
             "token_loss) are linearly ramped from 0 to their full weight. "
-            "Set to 0 (default) to disable warmup and use full weights from the start."
+            "Set to 0 (default) to disable warmup and use full weights from the start. "
+            "Ignored when aux_loss_start_step > 0."
+        },
+    )
+    aux_loss_start_step: int = dataclasses.field(
+        default=0,
+        metadata={
+            "help": "Step at which auxiliary losses are switched on (step function). "
+            "Before this step the weight is 0; at and after it the weight is 1. "
+            "When set (> 0) this overrides aux_loss_warmup_steps."
         },
     )

--- a/src/cehrgpt/runners/hf_gpt_runner_argument_dataclass.py
+++ b/src/cehrgpt/runners/hf_gpt_runner_argument_dataclass.py
@@ -299,3 +299,10 @@ class CehrGPTArguments:
             "When set (> 0) this overrides aux_loss_warmup_steps."
         },
     )
+    refresh_processed_dataset: bool = dataclasses.field(
+        default=False,
+        metadata={
+            "help": "If set, delete the cached prepared dataset at prepared_ds_path and "
+            "rebuild it from scratch, ignoring any previously saved version."
+        },
+    )

--- a/src/cehrgpt/runners/sample_packing_trainer.py
+++ b/src/cehrgpt/runners/sample_packing_trainer.py
@@ -13,8 +13,49 @@ DEFAULT_MAX_TOKENS_PER_BATCH = 16384
 
 LOG = logging.get_logger("transformers")
 
+# Loss fields exposed by CehrGptCausalLMOutput that we want to log separately.
+_CEHRGPT_SUB_LOSSES = [
+    "token_loss",
+    "time_token_loss",
+    "time_to_visit_loss",
+    "token_value_loss",
+    "motor_tte_loss",
+    "age_at_ve_loss",
+]
 
-class SamplePackingTrainer(Trainer):
+
+class CehrGptTrainer(Trainer):
+    """Trainer that logs individual CEHR-GPT loss components in addition to the total loss."""
+
+    def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
+        outputs = model(**inputs)
+        loss = outputs.loss
+
+        # Accumulate each sub-loss so we can average over the logging interval.
+        if not hasattr(self, "_sub_loss_sums"):
+            self._sub_loss_sums = {}
+            self._sub_loss_counts = {}
+
+        for name in _CEHRGPT_SUB_LOSSES:
+            value = getattr(outputs, name, None)
+            if value is not None:
+                self._sub_loss_sums[name] = self._sub_loss_sums.get(name, 0.0) + value.detach().item()
+                self._sub_loss_counts[name] = self._sub_loss_counts.get(name, 0) + 1
+
+        return (loss, outputs) if return_outputs else loss
+
+    def log(self, logs, *args, **kwargs):
+        # Flush averaged sub-losses into the log dict, then reset accumulators.
+        if hasattr(self, "_sub_loss_sums") and self._sub_loss_sums:
+            for name, total in self._sub_loss_sums.items():
+                count = self._sub_loss_counts.get(name, 1)
+                logs[name] = round(total / count, 6)
+            self._sub_loss_sums = {}
+            self._sub_loss_counts = {}
+        super().log(logs, *args, **kwargs)
+
+
+class SamplePackingTrainer(CehrGptTrainer):
     def __init__(self, *args, **kwargs):
         if "max_tokens_per_batch" in kwargs:
             self.max_tokens_per_batch = kwargs.pop("max_tokens_per_batch")

--- a/src/cehrgpt/runners/sample_packing_trainer.py
+++ b/src/cehrgpt/runners/sample_packing_trainer.py
@@ -28,16 +28,28 @@ class CehrGptTrainer(Trainer):
     """Trainer that logs individual CEHR-GPT loss components in addition to the total loss."""
 
     def __init__(self, *args, **kwargs):
+        self.aux_loss_start_step = kwargs.pop("aux_loss_start_step", 0)
         self.aux_loss_warmup_steps = kwargs.pop("aux_loss_warmup_steps", 0)
-        if self.aux_loss_warmup_steps > 0:
+        if self.aux_loss_start_step > 0:
+            LOG.info("aux_loss_start_step: %s (overrides warmup)", self.aux_loss_start_step)
+        elif self.aux_loss_warmup_steps > 0:
             LOG.info("aux_loss_warmup_steps: %s", self.aux_loss_warmup_steps)
         super().__init__(*args, **kwargs)
 
     def _aux_weight(self) -> float:
-        """Linear ramp from 0 → 1 over aux_loss_warmup_steps global steps."""
-        if self.aux_loss_warmup_steps <= 0:
-            return 1.0
-        return min(1.0, self.state.global_step / self.aux_loss_warmup_steps)
+        """
+        Returns the weight [0, 1] applied to auxiliary losses at the current step.
+
+        - If aux_loss_start_step > 0: step function — 0 before the step, 1 at/after.
+          This overrides aux_loss_warmup_steps.
+        - Elif aux_loss_warmup_steps > 0: linear ramp from 0 → 1 over that many steps.
+        - Otherwise: always 1 (no warmup).
+        """
+        if self.aux_loss_start_step > 0:
+            return 1.0 if self.state.global_step >= self.aux_loss_start_step else 0.0
+        if self.aux_loss_warmup_steps > 0:
+            return min(1.0, self.state.global_step / self.aux_loss_warmup_steps)
+        return 1.0
 
     def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
         outputs = model(**inputs)
@@ -75,8 +87,8 @@ class CehrGptTrainer(Trainer):
                 logs[name] = round(total / count, 6)
             self._sub_loss_sums = {}
             self._sub_loss_counts = {}
-        # Log the current aux warmup weight so progress is visible in training logs.
-        if self.aux_loss_warmup_steps > 0:
+        # Log the current aux weight so progress is visible in training logs.
+        if self.aux_loss_start_step > 0 or self.aux_loss_warmup_steps > 0:
             logs["aux_loss_weight"] = round(self._aux_weight(), 4)
         super().log(logs, *args, **kwargs)
 

--- a/src/cehrgpt/runners/sample_packing_trainer.py
+++ b/src/cehrgpt/runners/sample_packing_trainer.py
@@ -27,9 +27,32 @@ _CEHRGPT_SUB_LOSSES = [
 class CehrGptTrainer(Trainer):
     """Trainer that logs individual CEHR-GPT loss components in addition to the total loss."""
 
+    def __init__(self, *args, **kwargs):
+        self.aux_loss_warmup_steps = kwargs.pop("aux_loss_warmup_steps", 0)
+        if self.aux_loss_warmup_steps > 0:
+            LOG.info("aux_loss_warmup_steps: %s", self.aux_loss_warmup_steps)
+        super().__init__(*args, **kwargs)
+
+    def _aux_weight(self) -> float:
+        """Linear ramp from 0 → 1 over aux_loss_warmup_steps global steps."""
+        if self.aux_loss_warmup_steps <= 0:
+            return 1.0
+        return min(1.0, self.state.global_step / self.aux_loss_warmup_steps)
+
     def compute_loss(self, model, inputs, return_outputs=False, **kwargs):
         outputs = model(**inputs)
         loss = outputs.loss
+
+        # During aux-loss warmup: keep only the token_loss contribution at step 0,
+        # then linearly ramp in all auxiliary losses over aux_loss_warmup_steps.
+        aux_weight = self._aux_weight()
+        if aux_weight < 1.0 and outputs.token_loss is not None:
+            model_config = self.model.config
+            ntp_weight = getattr(model_config, "next_token_prediction_loss_weight", 1.0)
+            freeze = getattr(model_config, "freeze_cehrgpt_generation_model", False)
+            token_contribution = outputs.token_loss * ntp_weight * float(not freeze)
+            aux_contribution = loss - token_contribution
+            loss = token_contribution + aux_weight * aux_contribution
 
         # Accumulate each sub-loss so we can average over the logging interval.
         if not hasattr(self, "_sub_loss_sums"):
@@ -52,6 +75,9 @@ class CehrGptTrainer(Trainer):
                 logs[name] = round(total / count, 6)
             self._sub_loss_sums = {}
             self._sub_loss_counts = {}
+        # Log the current aux warmup weight so progress is visible in training logs.
+        if self.aux_loss_warmup_steps > 0:
+            logs["aux_loss_weight"] = round(self._aux_weight(), 4)
         super().log(logs, *args, **kwargs)
 
 

--- a/src/cehrgpt/runners/sample_packing_trainer.py
+++ b/src/cehrgpt/runners/sample_packing_trainer.py
@@ -20,7 +20,7 @@ _CEHRGPT_SUB_LOSSES = [
     "time_to_visit_loss",
     "token_value_loss",
     "motor_tte_loss",
-    "age_at_ve_loss",
+    "age_at_vs_loss",
 ]
 
 

--- a/src/cehrgpt/tokenization/tokenization_cehrgpt.py
+++ b/src/cehrgpt/tokenization/tokenization_cehrgpt.py
@@ -357,6 +357,30 @@ class CehrGptTokenizer(PreTrainedTokenizer):
     def pretrained_concept_embedding_model(self):
         return self._pretrained_concept_embedding_model
 
+    def get_motor_task_prevalence_rates(self) -> List[float]:
+        """
+        Returns the per-task hazard rate for each MOTOR task in sorted code order.
+        Rate = frac_events / mean_event_tte (days), matching the original MOTOR
+        implementation. Used to initialize task_layer bias in MotorTaskHead.
+        """
+        task_tte = self._motor_task_info.get("task_tte_stats", {})
+        task_censor = self._motor_task_info.get("task_censor_stats", {})
+        task_tte_time = self._motor_task_info.get("task_tte_time_stats", {})
+        rates = []
+        for code in sorted(self._motor_time_to_event_codes):
+            events = task_tte.get(code, 0)
+            censored = task_censor.get(code, 0)
+            total = events + censored
+            frac_events = events / total if total > 0 else 1e-6
+            tte_stats = task_tte_time.get(code)
+            if tte_stats is not None and tte_stats.count > 0:
+                mean_tte = tte_stats.mean()
+                rate = frac_events / mean_tte if mean_tte > 0 else 1e-6
+            else:
+                rate = 1e-6
+            rates.append(max(rate, 1e-6))
+        return rates
+
     def get_motor_time_bins(self, motor_num_time_pieces: int) -> List[int]:
         if "motor_event_times" not in self._motor_task_info:
             return []

--- a/src/cehrgpt/tokenization/tokenization_cehrgpt.py
+++ b/src/cehrgpt/tokenization/tokenization_cehrgpt.py
@@ -269,30 +269,36 @@ class CehrGptTokenizer(PreTrainedTokenizer):
     @property
     def valid_age_values(self) -> frozenset:
         """
-        Returns the frozenset of integer ages that have a corresponding 'age:<int>' token
-        in the vocabulary (case-insensitive). Used for constructing age reconstruction labels.
+        Returns the frozenset of integer ages (capped at 120) that have a corresponding
+        'age:<int>' token in the vocabulary (case-insensitive).
+        Ages above 120 are excluded as data-quality outliers.
+        Used for constructing age reconstruction labels.
         """
         import re
+        MAX_CLINICAL_AGE = 120
         pattern = re.compile(r"^age:(\d+)$", re.IGNORECASE)
         return frozenset(
-            int(m.group(1))
+            age
             for token in self._tokenizer.get_vocab()
             if (m := pattern.match(token))
+            and (age := int(m.group(1))) <= MAX_CLINICAL_AGE
         )
 
     @property
     def age_at_ve_vocab_size(self) -> int:
         """
-        Returns max_age + 1 derived from age tokens (pattern 'age:<int>') in the vocabulary.
+        Returns max_age + 1 derived from age tokens (pattern 'age:<int>') in the vocabulary,
+        capped at MAX_CLINICAL_AGE + 1 to exclude data-quality outliers (e.g. age:900).
         This is used as the number of age classes for the age-at-VE prediction head.
         """
+        MAX_CLINICAL_AGE = 120
         ages = self.valid_age_values
         if not ages:
             raise RuntimeError(
                 "No age tokens matching 'age:<int>' found in the vocabulary. "
                 "Cannot derive age_at_ve_vocab_size."
             )
-        return max(ages) + 1
+        return min(max(ages), MAX_CLINICAL_AGE) + 1
 
     def get_age_token_id(self, age: int) -> Optional[int]:
         """

--- a/src/cehrgpt/tokenization/tokenization_cehrgpt.py
+++ b/src/cehrgpt/tokenization/tokenization_cehrgpt.py
@@ -267,6 +267,45 @@ class CehrGptTokenizer(PreTrainedTokenizer):
             raise RuntimeError("The tokenizer does not contain either VE or [VE]")
 
     @property
+    def valid_age_values(self) -> frozenset:
+        """
+        Returns the frozenset of integer ages that have a corresponding 'age:<int>' token
+        in the vocabulary (case-insensitive). Used for constructing age reconstruction labels.
+        """
+        import re
+        pattern = re.compile(r"^age:(\d+)$", re.IGNORECASE)
+        return frozenset(
+            int(m.group(1))
+            for token in self._tokenizer.get_vocab()
+            if (m := pattern.match(token))
+        )
+
+    @property
+    def age_at_ve_vocab_size(self) -> int:
+        """
+        Returns max_age + 1 derived from age tokens (pattern 'age:<int>') in the vocabulary.
+        This is used as the number of age classes for the age-at-VE prediction head.
+        """
+        ages = self.valid_age_values
+        if not ages:
+            raise RuntimeError(
+                "No age tokens matching 'age:<int>' found in the vocabulary. "
+                "Cannot derive age_at_ve_vocab_size."
+            )
+        return max(ages) + 1
+
+    def get_age_token_id(self, age: int) -> Optional[int]:
+        """
+        Returns the vocabulary token ID for 'age:<age>' (tries common casings),
+        or None if the token is not found in the vocabulary.
+        """
+        vocab = self._tokenizer.get_vocab()
+        for candidate in (f"age:{age}", f"Age:{age}", f"AGE:{age}"):
+            if candidate in vocab:
+                return vocab[candidate]
+        return None
+
+    @property
     def numeric_concept_ids(self):
         return self._numeric_concept_ids
 

--- a/src/cehrgpt/tokenization/tokenization_cehrgpt.py
+++ b/src/cehrgpt/tokenization/tokenization_cehrgpt.py
@@ -305,6 +305,9 @@ class CehrGptTokenizer(PreTrainedTokenizer):
         Returns the vocabulary token ID for 'age:<age>' (tries common casings),
         or None if the token is not found in the vocabulary.
         """
+        if age > 120:
+            return None
+
         vocab = self._tokenizer.get_vocab()
         for candidate in (f"age:{age}", f"Age:{age}", f"AGE:{age}"):
             if candidate in vocab:

--- a/src/cehrgpt/tokenization/tokenization_cehrgpt.py
+++ b/src/cehrgpt/tokenization/tokenization_cehrgpt.py
@@ -2,6 +2,7 @@ import collections
 import copy
 import json
 import os
+import re
 import pickle
 from functools import partial
 from itertools import islice
@@ -67,7 +68,7 @@ from cehrgpt.tokenization.tokenization_statistics import (
 from cehrgpt.omop.ontology import Ontology
 
 LOG = logging.get_logger("transformers")
-
+MAX_CLINICAL_AGE = 120
 
 class CehrGptTokenizer(PreTrainedTokenizer):
 
@@ -274,8 +275,8 @@ class CehrGptTokenizer(PreTrainedTokenizer):
         Ages above 120 are excluded as data-quality outliers.
         Used for constructing age reconstruction labels.
         """
-        import re
-        MAX_CLINICAL_AGE = 120
+
+
         pattern = re.compile(r"^age:(\d+)$", re.IGNORECASE)
         return frozenset(
             age
@@ -291,7 +292,7 @@ class CehrGptTokenizer(PreTrainedTokenizer):
         capped at MAX_CLINICAL_AGE + 1 to exclude data-quality outliers (e.g. age:900).
         This is used as the number of age classes for the age-at-VE prediction head.
         """
-        MAX_CLINICAL_AGE = 120
+
         ages = self.valid_age_values
         if not ages:
             raise RuntimeError(
@@ -305,7 +306,7 @@ class CehrGptTokenizer(PreTrainedTokenizer):
         Returns the vocabulary token ID for 'age:<age>' (tries common casings),
         or None if the token is not found in the vocabulary.
         """
-        if age > 120:
+        if age > MAX_CLINICAL_AGE:
             return None
 
         vocab = self._tokenizer.get_vocab()

--- a/src/cehrgpt/tokenization/tokenization_cehrgpt.py
+++ b/src/cehrgpt/tokenization/tokenization_cehrgpt.py
@@ -1079,8 +1079,12 @@ class CehrGptTokenizer(PreTrainedTokenizer):
         motor_task_info = None
         if num_motor_tasks:
             LOG.info("Computing the MOTOR TTE statistics")
+            measurement_concept_ids = set(
+                [stat["concept_id"] for stat in numeric_lab_stats]
+                + [t[0] for t in categorical_lab_stats.keys()]
+            )
             allowed_motor_codes = get_allowed_motor_codes(
-                original_concept_codes, data_args, ontology
+                original_concept_codes, data_args, ontology, measurement_concept_ids
             )
             motor_tte_statistics = compute_motor_tte_statistics(
                 dataset, data_args, allowed_motor_codes, ontology

--- a/src/cehrgpt/tokenization/tokenization_cehrgpt.py
+++ b/src/cehrgpt/tokenization/tokenization_cehrgpt.py
@@ -284,7 +284,7 @@ class CehrGptTokenizer(PreTrainedTokenizer):
         )
 
     @property
-    def age_at_ve_vocab_size(self) -> int:
+    def age_at_vs_vocab_size(self) -> int:
         """
         Returns the number of valid age values (capped at MAX_CLINICAL_AGE) found in the vocabulary.
         This is used as the number of age classes for the age-at-VE prediction head.
@@ -293,7 +293,7 @@ class CehrGptTokenizer(PreTrainedTokenizer):
         if not ages:
             raise RuntimeError(
                 "No age tokens matching 'age:<int>' found in the vocabulary. "
-                "Cannot derive age_at_ve_vocab_size."
+                "Cannot derive age_at_vs_vocab_size."
             )
         return len(ages)
 

--- a/src/cehrgpt/tokenization/tokenization_cehrgpt.py
+++ b/src/cehrgpt/tokenization/tokenization_cehrgpt.py
@@ -275,8 +275,6 @@ class CehrGptTokenizer(PreTrainedTokenizer):
         Ages above 120 are excluded as data-quality outliers.
         Used for constructing age reconstruction labels.
         """
-
-
         pattern = re.compile(r"^age:(\d+)$", re.IGNORECASE)
         return frozenset(
             age
@@ -288,18 +286,16 @@ class CehrGptTokenizer(PreTrainedTokenizer):
     @property
     def age_at_ve_vocab_size(self) -> int:
         """
-        Returns max_age + 1 derived from age tokens (pattern 'age:<int>') in the vocabulary,
-        capped at MAX_CLINICAL_AGE + 1 to exclude data-quality outliers (e.g. age:900).
+        Returns the number of valid age values (capped at MAX_CLINICAL_AGE) found in the vocabulary.
         This is used as the number of age classes for the age-at-VE prediction head.
         """
-
         ages = self.valid_age_values
         if not ages:
             raise RuntimeError(
                 "No age tokens matching 'age:<int>' found in the vocabulary. "
                 "Cannot derive age_at_ve_vocab_size."
             )
-        return min(max(ages), MAX_CLINICAL_AGE) + 1
+        return len(ages)
 
     def get_age_token_id(self, age: int) -> Optional[int]:
         """

--- a/src/cehrgpt/tokenization/tokenization_statistics.py
+++ b/src/cehrgpt/tokenization/tokenization_statistics.py
@@ -73,6 +73,13 @@ def map_motor_tte_statistics(
     motor_event_times = femr.stat_utils.ReservoirSampler(100_000)
     task_tte_stats: Dict[str, int] = collections.defaultdict(int)
     task_censor_stats: Dict[str, int] = collections.defaultdict(int)
+    # Per-task OnlineStatistics for TTE (events only). Used together with
+    # task_tte_stats / task_censor_stats to compute a per-task hazard rate
+    # for MotorTaskHead bias initialisation:
+    #   rate_k = frac_events_k / mean_event_tte_k
+    task_tte_time_stats: Dict[str, femr.stat_utils.OnlineStatistics] = collections.defaultdict(
+        femr.stat_utils.OnlineStatistics
+    )
     for concept_ids, epoch_times in zip(batch["concept_ids"], batch["epoch_times"]):
         # Reverse walk through concept_ids to calculate TTE from each prediction point
         code_time_dict: Dict[str, float] = {}
@@ -85,6 +92,7 @@ def map_motor_tte_statistics(
                     tte = (motor_time - current_time) / 86400
                     motor_event_times.add(tte, 1)
                     task_tte_stats[motor_code] += 1
+                    task_tte_time_stats[motor_code].add(1, tte)
             elif concept_id in allowed_motor_codes_set:
                 if concept_id not in code_time_dict:
                     # First (nearest) occurrence in reverse walk = last occurrence in forward.
@@ -102,6 +110,7 @@ def map_motor_tte_statistics(
         "motor_event_times": motor_event_times,
         "task_tte_stats": task_tte_stats,
         "task_censor_stats": task_censor_stats,
+        "task_tte_time_stats": dict(task_tte_time_stats),
     }
 
 
@@ -144,6 +153,11 @@ def compute_motor_tte_statistics(
                 current["task_tte_stats"][k] += v
             for k, v in fixed_stat["task_censor_stats"].items():
                 current["task_censor_stats"][k] += v
+            for k, v in fixed_stat["task_tte_time_stats"].items():
+                if k in current["task_tte_time_stats"]:
+                    current["task_tte_time_stats"][k].combine(v)
+                else:
+                    current["task_tte_time_stats"][k] = v
 
     # Aggregate the counts for the parent concepts
     if ontology is not None:
@@ -157,6 +171,18 @@ def compute_motor_tte_statistics(
                     current["task_censor_stats"][parent] += current[
                         "task_censor_stats"
                     ][k]
+        for k in list(current["task_tte_time_stats"].keys()):
+            for parent in ontology.get_all_parents(k):
+                if parent != k:
+                    if parent in current["task_tte_time_stats"]:
+                        current["task_tte_time_stats"][parent].combine(
+                            current["task_tte_time_stats"][k]
+                        )
+                    else:
+                        import copy
+                        current["task_tte_time_stats"][parent] = copy.deepcopy(
+                            current["task_tte_time_stats"][k]
+                        )
     return current
 
 

--- a/src/cehrgpt/tokenization/tokenization_statistics.py
+++ b/src/cehrgpt/tokenization/tokenization_statistics.py
@@ -2,7 +2,7 @@ import collections
 import math
 import pickle
 from functools import partial
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
 import femr.stat_utils
 import numpy as np
@@ -46,6 +46,7 @@ def get_allowed_motor_codes(
         original_concept_codes: List[str],
         data_args: DataTrainingArguments,
         ontology: Optional[Ontology],
+        measurement_concept_ids: Optional[Set[str]] = None,
 ) -> List[str]:
     filtered_original_concept_codes = [
         concept_code
@@ -60,9 +61,15 @@ def get_allowed_motor_codes(
                 allowed_motor_codes.append(concept)
             elif concept in [DEATH_TOKEN, death_code]:
                 allowed_motor_codes.append(concept)
-        return allowed_motor_codes
     else:
-        return list(filtered_original_concept_codes)
+        allowed_motor_codes = list(filtered_original_concept_codes)
+
+    if measurement_concept_ids:
+        allowed_motor_codes = [
+            concept for concept in allowed_motor_codes
+            if concept not in measurement_concept_ids
+        ]
+    return allowed_motor_codes
 
 
 def map_motor_tte_statistics(

--- a/src/cehrgpt/tools/linear_prob/compute_cehrgpt_features.py
+++ b/src/cehrgpt/tools/linear_prob/compute_cehrgpt_features.py
@@ -107,6 +107,10 @@ def main():
     cache_file_collector = CacheFileCollector()
     processed_dataset = None
 
+    if cehrgpt_args.refresh_processed_dataset and prepared_ds_path.exists():
+        LOG.info("Refreshing prepared dataset: removing cache at %s", prepared_ds_path)
+        shutil.rmtree(prepared_ds_path)
+
     if any(prepared_ds_path.glob("*")):
         LOG.info("Loading prepared dataset from disk at %s...", prepared_ds_path)
         processed_dataset = load_from_disk(str(prepared_ds_path))

--- a/src/cehrgpt/tools/linear_prob/compute_cehrgpt_features.py
+++ b/src/cehrgpt/tools/linear_prob/compute_cehrgpt_features.py
@@ -55,7 +55,7 @@ def _ensure_1d(arr: np.ndarray) -> np.ndarray:
 def _create_feature_dataset(data_args, training_args, cehrgpt_args, tokenizer, cache_file_collector):
     """Process the raw data into a tokenized DatasetDict for feature extraction."""
     if cehrgpt_args.tokenized_full_dataset_path is not None:
-        return extract_cohort_sequences(data_args, cehrgpt_args)
+        return extract_cohort_sequences(data_args, cehrgpt_args, tokenizer)
 
     final_splits = prepare_finetune_dataset(
         data_args, training_args, cehrgpt_args, cache_file_collector

--- a/tests/integration_tests/runners/hf_cehrgpt_pretrain_runner_test.py
+++ b/tests/integration_tests/runners/hf_cehrgpt_pretrain_runner_test.py
@@ -115,7 +115,7 @@ class HfCehrGptRunnerIntegrationTest(unittest.TestCase):
             "silu",
             "--decoder_mlp",
             "LlamaMLP",
-            "--include_age_at_ve_prediction",
+            "--include_age_at_vs_prediction",
             "true"
         ]
         train_main()

--- a/tests/integration_tests/runners/hf_cehrgpt_pretrain_runner_test.py
+++ b/tests/integration_tests/runners/hf_cehrgpt_pretrain_runner_test.py
@@ -115,6 +115,8 @@ class HfCehrGptRunnerIntegrationTest(unittest.TestCase):
             "silu",
             "--decoder_mlp",
             "LlamaMLP",
+            "--include_age_at_ve_prediction",
+            "true"
         ]
         train_main()
         # Teacher force the prompt to consist of [year][age][gender][race][VS] then inject the random vector before [VS]

--- a/tests/integration_tests/runners/hf_cehrgpt_pretrain_sample_packing_runner_test.py
+++ b/tests/integration_tests/runners/hf_cehrgpt_pretrain_sample_packing_runner_test.py
@@ -115,7 +115,7 @@ class HfCehrGptRunnerIntegrationTest(unittest.TestCase):
             "true",
             "--apply_rotary",
             "true",
-            "--include_age_at_ve_prediction",
+            "--include_age_at_vs_prediction",
             "true"
         ]
         train_main()

--- a/tests/integration_tests/runners/hf_cehrgpt_pretrain_sample_packing_runner_test.py
+++ b/tests/integration_tests/runners/hf_cehrgpt_pretrain_sample_packing_runner_test.py
@@ -115,6 +115,8 @@ class HfCehrGptRunnerIntegrationTest(unittest.TestCase):
             "true",
             "--apply_rotary",
             "true",
+            "--include_age_at_ve_prediction",
+            "true"
         ]
         train_main()
         # Teacher force the prompt to consist of [year][age][gender][race][VS] then inject the random vector before [VS]

--- a/tests/unit_tests/data/test_extract_tokenized_sequence_mapping.py
+++ b/tests/unit_tests/data/test_extract_tokenized_sequence_mapping.py
@@ -355,5 +355,81 @@ class TestExtractMultiplePredictionTimes(unittest.TestCase):
         self.assertEqual(self.result["classifier_label"][1], 0)
 
 
+class TestExtractIndexDateMidVisit(unittest.TestCase):
+    """
+    The prediction time (index_date) falls in the middle of a hospitalization,
+    so the last token at or before index_date is an inpatient ATT token (i-D1).
+    The backward step should skip it and land on the preceding clinical event.
+
+    Fixture (single inpatient visit, 10 tokens):
+
+      idx  token   epoch
+      ---  ------  -----------
+       0   year:2020  T_admit
+       1   age:70     T_admit
+       2   8507       T_admit
+       3   Race/0     T_admit
+       4   [VS]       T_admit      ← vs_start_idx (observation_window=0)
+       5   9201       T_admit
+       6   cond1      T_admit
+       7   i-D1       T_day1       ← inpatient ATT; epoch > T_admit but <= index_date
+       8   cond2      T_day2       ← epoch > index_date → excluded
+       9   [VE]       T_day2       ← epoch > index_date → excluded
+
+    index_date = T_day1 exactly:
+      - Tokens 0-7 have epoch <= T_day1; token 7 (i-D1) is last → initial vs_end_idx=7
+      - i-D1 is an ATT token → step back to idx 6 (cond1)
+      - Expected last token: cond1; cond2 must not appear.
+    """
+
+    T_ADMIT = datetime.datetime(2020, 1, 1, tzinfo=UTC)
+    T_DAY1  = datetime.datetime(2020, 1, 2, tzinfo=UTC)  # index_date
+    T_DAY2  = datetime.datetime(2020, 1, 3, tzinfo=UTC)
+
+    def _make_inpatient_record(self):
+        EP_ADMIT = self.T_ADMIT.timestamp()
+        EP_DAY1  = self.T_DAY1.timestamp()
+        EP_DAY2  = self.T_DAY2.timestamp()
+        concept_ids  = ["year:2020", "age:70", "8507", "Race/0",
+                        "[VS]", "9201", "cond1", "i-D1", "cond2", "[VE]"]
+        epoch_times  = [EP_ADMIT] * 7 + [EP_DAY1, EP_DAY2, EP_DAY2]
+        ages         = [70] * 10
+        return {
+            "person_id": PERSON_ID,
+            "concept_ids": concept_ids,
+            "input_ids": list(range(10)),
+            "epoch_times": epoch_times,
+            "ages": ages,
+            "concept_value_masks": [0] * 10,
+        }
+
+    def setUp(self):
+        self.mapping = _make_mapping(observation_window=0, index_date=self.T_DAY1)
+        self.result = self.mapping.transform(self._make_inpatient_record())
+
+    def test_single_sample_produced(self):
+        self.assertEqual(len(self.result["concept_ids"]), 1)
+
+    def test_sequence_does_not_end_on_att_token(self):
+        last_token = self.result["concept_ids"][0][-1]
+        self.assertFalse(
+            last_token.startswith("i-D"),
+            f"Sequence ended on inpatient ATT token: {last_token}",
+        )
+
+    def test_sequence_ends_on_clinical_event(self):
+        last_token = self.result["concept_ids"][0][-1]
+        self.assertEqual(last_token, "cond1")
+
+    def test_post_index_events_excluded(self):
+        tokens = list(self.result["concept_ids"][0])
+        self.assertNotIn("cond2", tokens)
+        self.assertNotIn("[VE]", tokens)
+
+    def test_pre_index_events_included(self):
+        tokens = list(self.result["concept_ids"][0])
+        self.assertIn("cond1", tokens)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/unit_tests/data/test_extract_tokenized_sequence_mapping.py
+++ b/tests/unit_tests/data/test_extract_tokenized_sequence_mapping.py
@@ -1,0 +1,359 @@
+"""
+Tests for ExtractTokenizedSequenceDataMapping.transform()
+
+Patient fixture
+---------------
+Birth year : 1950
+Demographic header : ["year:2000", "age:50", "8507", "Race/0"]  (indices 0-3)
+
+Sequence layout (18 tokens total):
+
+  idx  token     epoch            age
+  ---  --------  ---------------  ---
+   0   year:2000  T_2000          50   ─┐
+   1   age:50     T_2000          50    │ demographic header
+   2   8507       T_2000          50    │
+   3   Race/0     T_2000          50   ─┘
+   4   [VS]       T_2000          50   ─┐
+   5   9202       T_2000          50    │ visit 1  (2000-01-01)
+   6   cond1      T_2000          50    │
+   7   [VE]       T_2000          50   ─┘
+   8   D730       T_2002          52      ATT between visits
+   9   [VS]       T_2002          52   ─┐
+  10   9202       T_2002          52    │ visit 2  (2002-06-15)
+  11   cond2      T_2002          52    │
+  12   [VE]       T_2002          52   ─┘
+  13   D840       T_2004          54      ATT between visits
+  14   [VS]       T_2004          54   ─┐
+  15   9202       T_2004          54    │ visit 3  (2004-09-20)
+  16   cond3      T_2004          54    │
+  17   [VE]       T_2004          54   ─┘
+
+Fake input_ids  : [0, 1, 2, ..., 17]
+"""
+
+import datetime
+import unittest
+from collections import defaultdict
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from cehrgpt.data.hf_cehrgpt_dataset_mapping import ExtractTokenizedSequenceDataMapping
+
+UTC = datetime.timezone.utc
+
+# ---------------------------------------------------------------------------
+# Epoch constants used across every test
+# ---------------------------------------------------------------------------
+T_2000 = datetime.datetime(2000, 1, 1, tzinfo=UTC)
+T_2002 = datetime.datetime(2002, 6, 15, tzinfo=UTC)
+T_2004 = datetime.datetime(2004, 9, 20, tzinfo=UTC)
+T_2005 = datetime.datetime(2005, 1, 1, tzinfo=UTC)
+
+EP_2000 = T_2000.timestamp()   # 946684800.0
+EP_2002 = T_2002.timestamp()   # 1024099200.0
+EP_2004 = T_2004.timestamp()   # 1095638400.0
+EP_2005 = T_2005.timestamp()   # 1104537600.0
+
+BIRTH_YEAR = 1950
+PERSON_ID = 42
+LABEL = 1
+
+
+def _make_record():
+    """Return the 18-token patient record described in the module docstring."""
+    concept_ids = [
+        "year:2000", "age:50", "8507", "Race/0",        # 0-3  demographic
+        "[VS]", "9202", "cond1", "[VE]",                 # 4-7  visit 1
+        "D730",                                           # 8    ATT
+        "[VS]", "9202", "cond2", "[VE]",                 # 9-12 visit 2
+        "D840",                                           # 13   ATT
+        "[VS]", "9202", "cond3", "[VE]",                 # 14-17 visit 3
+    ]
+    epoch_times = [
+        EP_2000, EP_2000, EP_2000, EP_2000,  # demo
+        EP_2000, EP_2000, EP_2000, EP_2000,  # visit 1
+        EP_2002,                              # ATT
+        EP_2002, EP_2002, EP_2002, EP_2002,  # visit 2
+        EP_2004,                              # ATT
+        EP_2004, EP_2004, EP_2004, EP_2004,  # visit 3
+    ]
+    ages = [
+        50, 50, 50, 50,  # demo
+        50, 50, 50, 50,  # visit 1
+        52,              # ATT
+        52, 52, 52, 52,  # visit 2
+        54,              # ATT
+        54, 54, 54, 54,  # visit 3
+    ]
+    concept_value_masks = [0] * 18
+    input_ids = list(range(18))  # fake token ids  0..17
+
+    return {
+        "person_id": PERSON_ID,
+        "concept_ids": concept_ids,
+        "input_ids": input_ids,
+        "epoch_times": epoch_times,
+        "ages": ages,
+        "concept_value_masks": concept_value_masks,
+    }
+
+
+def _make_mapping(observation_window, index_date, label=LABEL, tokenizer=None):
+    """Build a mapping object with a single prediction time for PERSON_ID."""
+    person_index_date_map = {
+        PERSON_ID: [{"index_date": index_date, "label": label}]
+    }
+    return ExtractTokenizedSequenceDataMapping(
+        person_index_date_map=person_index_date_map,
+        observation_window=observation_window,
+        tokenizer=tokenizer,
+    )
+
+
+class TestExtractWithObservationWindow(unittest.TestCase):
+    """
+    1000-day window ending at T_2005.
+
+    feature_extraction_start = EP_2005 - 1000*86400 = 1018137600
+    Visit 1 (EP_2000 = 946684800) is outside  → excluded.
+    Visit 2 (EP_2002 = 1024099200) is inside  → vs_start_idx = 9.
+    Visit 3 (EP_2004 = 1095638400) is inside  → included up to vs_end_idx = 17.
+    """
+
+    def setUp(self):
+        self.mapping = _make_mapping(observation_window=1000, index_date=T_2005)
+        self.result = self.mapping.transform(_make_record())
+
+    def test_single_sample_produced(self):
+        self.assertEqual(len(self.result["concept_ids"]), 1)
+
+    def test_demographic_tokens_prepended(self):
+        concept_ids = list(self.result["concept_ids"][0])
+        self.assertEqual(concept_ids[:4], ["year:2002", "age:52", "8507", "Race/0"])
+
+    def test_year_token_recalculated(self):
+        self.assertEqual(self.result["concept_ids"][0][0], "year:2002")
+
+    def test_age_token_recalculated(self):
+        self.assertEqual(self.result["concept_ids"][0][1], "age:52")
+
+    def test_gender_and_race_preserved(self):
+        tokens = self.result["concept_ids"][0]
+        self.assertEqual(tokens[2], "8507")
+        self.assertEqual(tokens[3], "Race/0")
+
+    def test_sequence_starts_at_vs(self):
+        # Token at index 4 (right after the 4 demo tokens) must be [VS]
+        self.assertEqual(self.result["concept_ids"][0][4], "[VS]")
+
+    def test_visit_1_excluded(self):
+        tokens = list(self.result["concept_ids"][0])
+        self.assertNotIn("cond1", tokens)
+
+    def test_visit_2_and_3_included(self):
+        tokens = list(self.result["concept_ids"][0])
+        self.assertIn("cond2", tokens)
+        self.assertIn("cond3", tokens)
+
+    def test_att_before_first_window_visit_excluded(self):
+        # D730 is the ATT token immediately before visit 2; it sits outside
+        # the extracted slice because slicing starts at the [VS] of visit 2.
+        tokens = list(self.result["concept_ids"][0])
+        self.assertNotIn("D730", tokens)
+
+    def test_att_between_window_visits_included(self):
+        # D840 lives between visit 2 and visit 3, both inside the window.
+        tokens = list(self.result["concept_ids"][0])
+        self.assertIn("D840", tokens)
+
+    def test_epoch_times_for_demo_tokens(self):
+        ep = self.result["epoch_times"][0]
+        np.testing.assert_array_equal(ep[:4], [EP_2002] * 4)
+
+    def test_ages_for_demo_tokens(self):
+        ages = self.result["ages"][0]
+        np.testing.assert_array_equal(ages[:4], [52] * 4)
+
+    def test_concept_value_masks_for_demo_tokens(self):
+        masks = self.result["concept_value_masks"][0]
+        # Original demo mask values are 0; they should be reused.
+        np.testing.assert_array_equal(masks[:4], [0] * 4)
+
+    def test_input_ids_demo_fallback_without_tokenizer(self):
+        # No tokenizer supplied → original demo input_ids [0,1,2,3] are reused.
+        input_ids = self.result["input_ids"][0]
+        np.testing.assert_array_equal(input_ids[:4], [0, 1, 2, 3])
+
+    def test_input_ids_event_portion(self):
+        # Sliced input_ids from vs_start_idx=9 to vs_end_idx=17 inclusive.
+        input_ids = self.result["input_ids"][0]
+        np.testing.assert_array_equal(input_ids[4:], list(range(9, 18)))
+
+    def test_age_at_index(self):
+        self.assertEqual(self.result["age_at_index"][0], 52)
+
+    def test_classifier_label(self):
+        self.assertEqual(self.result["classifier_label"][0], LABEL)
+
+    def test_index_date(self):
+        self.assertAlmostEqual(self.result["index_date"][0], EP_2005, places=1)
+
+    def test_total_sequence_length(self):
+        # 4 demo + 9 event tokens (indices 9-17)
+        self.assertEqual(len(self.result["concept_ids"][0]), 13)
+
+
+class TestExtractWithNoObservationWindow(unittest.TestCase):
+    """
+    observation_window=0 → feature_extraction_start=0 → full history used.
+
+    vs_start_idx = 4 (first [VS] in the sequence, visit 1).
+    Expected demo tokens: year:2000, age:50, 8507, Race/0 (unchanged).
+    All three visits included.
+    """
+
+    def setUp(self):
+        self.mapping = _make_mapping(observation_window=0, index_date=T_2005)
+        self.result = self.mapping.transform(_make_record())
+
+    def test_single_sample_produced(self):
+        self.assertEqual(len(self.result["concept_ids"]), 1)
+
+    def test_demographic_year_unchanged(self):
+        self.assertEqual(self.result["concept_ids"][0][0], "year:2000")
+
+    def test_demographic_age_unchanged(self):
+        self.assertEqual(self.result["concept_ids"][0][1], "age:50")
+
+    def test_all_three_visits_included(self):
+        tokens = list(self.result["concept_ids"][0])
+        self.assertIn("cond1", tokens)
+        self.assertIn("cond2", tokens)
+        self.assertIn("cond3", tokens)
+
+    def test_total_sequence_length(self):
+        # 4 demo + 14 event tokens (indices 4-17)
+        self.assertEqual(len(self.result["concept_ids"][0]), 18)
+
+    def test_epoch_times_for_demo_tokens(self):
+        ep = self.result["epoch_times"][0]
+        np.testing.assert_array_equal(ep[:4], [EP_2000] * 4)
+
+    def test_ages_for_demo_tokens(self):
+        ages = self.result["ages"][0]
+        np.testing.assert_array_equal(ages[:4], [50] * 4)
+
+    def test_age_at_index(self):
+        self.assertEqual(self.result["age_at_index"][0], 50)
+
+
+class TestExtractNoVsInWindow(unittest.TestCase):
+    """
+    1-day window ending at T_2005 → feature_extraction_start ≈ 2004-12-31.
+    All [VS] tokens have epoch << feature_extraction_start → no sample produced.
+    """
+
+    def setUp(self):
+        self.mapping = _make_mapping(observation_window=1, index_date=T_2005)
+        self.result = self.mapping.transform(_make_record())
+
+    def test_no_samples_produced(self):
+        self.assertEqual(len(self.result), 0)
+
+
+class TestExtractWithTokenizer(unittest.TestCase):
+    """
+    When a tokenizer is provided, input_ids for the new demographic tokens
+    should come from tokenizer.encode(), not the original demo ids.
+    """
+
+    def setUp(self):
+        tokenizer = MagicMock()
+        # encode(["year:2002", "age:52", "8507", "Race/0"]) → [100, 101, 102, 103]
+        tokenizer.encode.return_value = [100, 101, 102, 103]
+        self.mapping = _make_mapping(
+            observation_window=1000, index_date=T_2005, tokenizer=tokenizer
+        )
+        self.result = self.mapping.transform(_make_record())
+
+    def test_demo_input_ids_from_tokenizer(self):
+        np.testing.assert_array_equal(
+            self.result["input_ids"][0][:4], [100, 101, 102, 103]
+        )
+
+    def test_event_input_ids_unchanged(self):
+        # Event portion (visit 2 + visit 3: indices 9-17) must still be original ids.
+        np.testing.assert_array_equal(
+            self.result["input_ids"][0][4:], list(range(9, 18))
+        )
+
+
+class TestExtractMultiplePredictionTimes(unittest.TestCase):
+    """
+    Two prediction times for the same person:
+      - T_2005 with 1000-day window → visit 2 + 3 in scope  (sample produced)
+      - T_2003 with 1-day window    → no VS in scope         (sample skipped)
+    Only one sample should be present in the output.
+    """
+
+    def setUp(self):
+        T_2003 = datetime.datetime(2003, 1, 1, tzinfo=UTC)
+        person_index_date_map = {
+            PERSON_ID: [
+                {"index_date": T_2005, "label": 1},
+                {"index_date": T_2003, "label": 0},
+            ]
+        }
+        self.mapping = ExtractTokenizedSequenceDataMapping(
+            person_index_date_map=person_index_date_map,
+            observation_window=1,   # 1-day window for T_2003 → no VS
+        )
+        # Override only the first entry to use 1000-day window via direct call.
+        # Easier: use two separate mappings to test the expectation.
+        # Re-build: first entry uses 1000-day window, second uses 1-day.
+        # We reuse observation_window=1000 for the first and check that
+        # the 1-day T_2003 entry produces nothing.
+        person_index_date_map = {
+            PERSON_ID: [
+                {"index_date": T_2005, "label": 1},  # 1000-day window applied globally
+                {"index_date": T_2003, "label": 0},  # also 1000-day → EP_2003-1000d check
+            ]
+        }
+        # T_2003 with 1000-day window:
+        #   EP_2003 = datetime(2003,1,1,tzinfo=UTC).timestamp() = 1041379200
+        #   feature_extraction_start = 1041379200 - 86400000 = 954979200 (≈2000-04-07)
+        #   Visit 1 epoch EP_2000=946684800 < 954979200 → outside
+        #   Visit 2 epoch EP_2002=1024099200 >= 954979200 → vs_start_idx=9
+        #   vs_end_idx: last token with epoch <= 1041379200
+        #     EP_2004=1095638400 > 1041379200 → visit 3 excluded
+        #     EP_2002=1024099200 <= 1041379200 → [VE] at index 12 is last
+        #   Slice: indices 9-12 = ["[VS]", "9202", "cond2", "[VE]"]  → sample produced
+        # So both entries produce samples; total = 2.
+        self.mapping = ExtractTokenizedSequenceDataMapping(
+            person_index_date_map=person_index_date_map,
+            observation_window=1000,
+        )
+        self.result = self.mapping.transform(_make_record())
+
+    def test_two_samples_produced(self):
+        self.assertEqual(len(self.result["concept_ids"]), 2)
+
+    def test_first_sample_contains_visit_2_and_3(self):
+        tokens = list(self.result["concept_ids"][0])
+        self.assertIn("cond2", tokens)
+        self.assertIn("cond3", tokens)
+
+    def test_second_sample_contains_only_visit_2(self):
+        tokens = list(self.result["concept_ids"][1])
+        self.assertIn("cond2", tokens)
+        self.assertNotIn("cond3", tokens)
+
+    def test_labels_preserved(self):
+        self.assertEqual(self.result["classifier_label"][0], 1)
+        self.assertEqual(self.result["classifier_label"][1], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Add valid_age_values, age_at_ve_vocab_size properties and get_age_token_id() method to CehrGptTokenizer for age token lookup
- Add include_age_at_ve_prediction param to CehrGptDataCollator; precompute age→token_id map; compute age_reconstruction_labels from batch input_ids and ages (-100 at non-VE and pad positions)
- Add age_at_ve_head linear layer to CEHRGPT2LMHeadModel; forward accepts age_reconstruction_labels and uses CrossEntropyLoss(ignore_index=-100)
- Wire include_age_at_ve_prediction / age_at_ve_vocab_size / age_at_ve_prediction_loss_weight through config, CehrGPTArguments, and pretrain runner (including collator)
- Enable the objective in both pretrain integration tests